### PR TITLE
Correções no código zzenviaemail.sh, apesar do teste incompleto

### DIFF
--- a/zz/zzenviaemail.sh
+++ b/zz/zzenviaemail.sh
@@ -16,7 +16,7 @@
 #
 # Autor: Lauro Cavalcanti de Sa <lauro (a) ecdesa com>
 # Desde: 2009-09-17
-# Versão: 20091010
+# Versão: 2
 # Licença: GPLv2
 # Requisitos: ssmtp
 # ----------------------------------------------------------------------------
@@ -27,7 +27,7 @@ zzenviaemail ()
 	# Declara variaveis.
 	local fromail tomail ccmail bccmail subject msgbody
 	local envia_data=`date +"%Y%m%d_%H%M%S_%N"`
-	local script_eml="${ZZTMPDIR}/.${FUNCNAME}_${envia_data}.eml"
+	local script_eml="${ZZTMP}.${FUNCNAME}_${envia_data}.eml"
 	local nparam=0
 
 	# Opcoes de linha de comando
@@ -91,7 +91,7 @@ zzenviaemail ()
 	echo "Bcc: ${bccmail}" >> ${script_eml}
 	echo "Subject: ${subject}" >> ${script_eml}
 	cat ${mensagem} >> ${script_eml}
-	ssmtp -F ${1} ${tomail} ${ccmail} ${bccmail} < ${script_eml}
+	ssmtp -F ${fromail} ${tomail} ${ccmail} ${bccmail} < ${script_eml}
 	if [ -s "${script_eml}" ] ; then
 		rm -f "${script_eml}"
 	fi


### PR DESCRIPTION
O número da versão foi corrigido; nany.sh o acusava. Rastriei até o commit 85e7345ab2c1b45e74312fbdf56a2c84ff46b6c5 e vi que versão 1 havia mudado para versão 20091010. Enfão fica versão 2. Fica versão 2 e não versão 3, ainda neste commit, porque as correções de hoje foram simples, linhas de código pontuais; e essas correções não puderam ser "completamente" testadas.

Note que este _pull request_ também fecha a _issue_ #99.

**TODO (?)** :  'ssmtp' é mostrado como requisito. Eu pensava que somente funções zz podiam sê-lo...
