### PR TITLE
Patch 1 - Adicionei umas abreviações comuns a cidade de Belo Horizonte.

### DIFF
--- a/zz/zzarrumacidade.sh
+++ b/zz/zzarrumacidade.sh
@@ -53,7 +53,7 @@ zzarrumacidade ()
 		### Restaura acentuação de maneira pontual:
 
 		# Restaura acentuação às capitais
-		s/^Belem$/Belém/op
+		s/^Belem$/Belém/
 		s/^Brasilia$/Brasília/
 		s/^Cuiaba$/Cuiabá/
 		s/^Florianopolis$/Florianópolis/


### PR DESCRIPTION
Adicionei umas abreviações comuns a cidade de **Belo Horizonte**. Não sei se é essa _BEM_ a ideia, mas seria legal se fosse colaborativo pro pessoal poder colocar. Claro, desde que não vire bagunça e não comprometa nenhum outro nome.

A ideia é que atendesse a:
- `B.H.`
- `B. Hte`
- `B. Hzte`
- `Belo Hte`
- `Belo Hzte`

fiz uma [expressão regular](http://regexr.com/?38jos) que atenderia, mas não soube como usar no `sed` e se é possível, inclusive.
