### PR TITLE
zzsigla: Correção da URL - V2

### DIFF
--- a/testador/zzsigla.sh
+++ b/testador/zzsigla.sh
@@ -8,6 +8,19 @@ DVD   Divers Droite (France, politics)
 DVD   Deutsche Vereinigung für Datenschutz
 DVD   Direct Vendor Delivery
 DVD   Developmental Verbal Dyspraxia
+DVD   Death Valley Driver (pro wrestling)
+DVD   D-Von Dudley (wrestler)
+DVD   Dissociated Vertical Deviation (ophthalmology)
+DVD   Digital Video Drive
+DVD   Dynamic Voltage Drop (electronics)
+DvD   Depp Vom Dienst (German: Idiot of Service)
+DVD   Double-Vessel Disease
+DVD   Digital Virtual Disk
+DVD   Drivers Vigilance Device (UK)
+DVD   Driver and Vehicle Data Online Access
+DVD   Diploma in Venerology & Dermatology (India)
+DVD   DC Video Deluxe (skateboarding)
+DVD   Definitie Van Dopeheid (Dutch: Definition of Permissible Dope)
 $ zzsigla
 Uso: zzsigla sigla
 $

--- a/zz/zzsigla.sh
+++ b/zz/zzsigla.sh
@@ -7,7 +7,7 @@
 #
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-02-21
-# Versão: 2
+# Versão: 3
 # Licença: GPL
 # ----------------------------------------------------------------------------
 zzsigla ()
@@ -27,6 +27,6 @@ zzsigla ()
 	#  a filtragem
 	$ZZWWWDUMP "$url?acronym=$sigla" |
 		grep -i "   $sigla " |
-		sed 's/^[ ]*//' |
-		sed 's/[ ][ ]*/   /'
+		sed 's/^ *//' |
+		sed 's/  */   /'
 }

--- a/zz/zzsigla.sh
+++ b/zz/zzsigla.sh
@@ -25,6 +25,8 @@ zzsigla ()
 	#  antes da sigla, e vários ou um espaço depois dependendo do 
 	#  tamanho da sigla. Assim, o grep utiliza aspas duplas para entender
 	#  a filtragem
-	$ZZWWWDUMP "$url?String=exact&Acronym=$sigla&Find=Find" |
-		grep -i "    $sigla "
+	$ZZWWWDUMP "$url?acronym=$sigla" |
+		grep -i "   $sigla " |
+		sed 's/^[ ]*//' |
+		sed 's/[ ][ ]*/   /'
 }


### PR DESCRIPTION
A API do site para realizar buscas mudou. A URL agora está muito mais simple.
Tratamento do resultado para remover espaços iniciais e deixar apenas 3 espaços entre a sigla e o significado.

Signed-off-by: Paulo Vital <pvital@gmail.com>