### PR TITLE
CPF não pode conter apenas zeros

### DIFF
--- a/testador/zzcpf.sh
+++ b/testador/zzcpf.sh
@@ -2,6 +2,10 @@
 $ zzcpf 123456789			#→ CPF inválido (deve ter 11 dígitos)
 $ zzcpf 123456789012			#→ CPF inválido (deve ter 11 dígitos)
 
+# CPF com apenas números zeros
+$ zzcpf 00000000000			#→ CPF inválido (não pode conter apenas zeros)
+$ zzcpf 000.000.000-00			#→ CPF inválido (não pode conter apenas zeros)
+
 # Dígito verificador incorreto
 $ zzcpf 12345678900			#→ CPF inválido (deveria terminar em 09)
 
@@ -45,14 +49,14 @@ $ zzcpf -f	987654321		#→ 009.876.543-21
 $ zzcpf -f	1987654321		#→ 019.876.543-21
 
 # -f: zeros à esquerda na entrada são removidos/ignorados
-$ zzcpf -f	0			#→ 000.000.000-00
-$ zzcpf -f	00000000000000000000	#→ 000.000.000-00
+$ zzcpf -f	0			#→ CPF inválido (não pode conter apenas zeros)
+$ zzcpf -f	00000000000000000000	#→ CPF inválido (não pode conter apenas zeros)
 $ zzcpf -f	000054321		#→ 000.000.543-21
 $ zzcpf -f	00000000000000054321	#→ 000.000.543-21
 
 # -f: Sem argumentos numéricos, assume zero
-$ zzcpf -f				#→ 000.000.000-00
-$ zzcpf -f	foo			#→ 000.000.000-00
+$ zzcpf -f				#→ CPF inválido (não pode conter apenas zeros)
+$ zzcpf -f	foo			#→ CPF inválido (não pode conter apenas zeros)
 
 # -f: remove símbolos e completa com zeros ao mesmo tempo
 $ zzcpf -f	'(1_2=3*4@5+6?7a8.'	#→ 000.123.456-78

--- a/zz/zzcpf.sh
+++ b/zz/zzcpf.sh
@@ -37,6 +37,12 @@ zzcpf ()
 			return 1
 		fi
 
+		if test ${cpf} -eq 0
+		then
+			zztool erro 'CPF inválido (não pode conter apenas zeros)'
+			return 1
+		fi
+
 		# Completa com zeros à esquerda, caso necessário
 		cpf=$(printf %011d "$cpf")
 
@@ -60,6 +66,12 @@ zzcpf ()
 		if test ${#cpf} -ne 11
 		then
 			zztool erro 'CPF inválido (deve ter 11 dígitos)'
+			return 1
+		fi
+
+		if test ${cpf} -eq 0
+		then
+			zztool erro 'CPF inválido (não pode conter apenas zeros)'
 			return 1
 		fi
 


### PR DESCRIPTION
No próprio site da receita podemos obter esse erro, diferente de 111.111.111-11 que é um CPF válido.

![screen shot 2015-03-07 at 7 04 08 pm](https://cloud.githubusercontent.com/assets/154023/6543504/c94692f6-c4fc-11e4-96f6-9b2e85e9a086.png)
