### PR TITLE
Testador sempre usar Bash

### DIFF
--- a/testador/run
+++ b/testador/run
@@ -10,11 +10,11 @@
 script_dir=$(dirname "$0")
 zz_root=$(cd "$script_dir"; cd ..; pwd)  # handles absolute and relative
 tmp='./run.tmp'
-tester='clitest'
+tester='bash clitest'
 
 # Check requirements
-bash $tester -V > /dev/null || {
-	printf '%s\n' "Ops... Não achei o programa testador: $tester"
+$tester -V > /dev/null || {
+	printf '%s\n' "Ops... Não achei o programa testador: clitest"
 	printf '%s\n' 'Baixe-o deste endereço:'
 	printf '%s\n' 'https://raw.github.com/aureliojargas/clitest/master/clitest'
 	exit 1
@@ -32,10 +32,10 @@ EOF
 if test $# -gt 0
 then
 	# Test specific file(s)
-	bash "$tester" --progress dot --pre-flight ". $tmp" "$@"
+	$tester --progress dot --pre-flight ". $tmp" "$@"
 else
 	# Test all files
-	bash "$tester" --progress dot --pre-flight ". $tmp" zz*.sh
+	$tester --progress dot --pre-flight ". $tmp" zz*.sh
 fi
 
 rm "$tmp"

--- a/testador/run
+++ b/testador/run
@@ -13,7 +13,7 @@ tmp='./run.tmp'
 tester='clitest'
 
 # Check requirements
-$tester -V > /dev/null || {
+bash $tester -V > /dev/null || {
 	printf '%s\n' "Ops... Não achei o programa testador: $tester"
 	printf '%s\n' 'Baixe-o deste endereço:'
 	printf '%s\n' 'https://raw.github.com/aureliojargas/clitest/master/clitest'
@@ -32,10 +32,10 @@ EOF
 if test $# -gt 0
 then
 	# Test specific file(s)
-	"$tester" --progress dot --pre-flight ". $tmp" "$@"
+	bash "$tester" --progress dot --pre-flight ". $tmp" "$@"
 else
 	# Test all files
-	"$tester" --progress dot --pre-flight ". $tmp" zz*.sh
+	bash "$tester" --progress dot --pre-flight ". $tmp" zz*.sh
 fi
 
 rm "$tmp"


### PR DESCRIPTION
O clitest usa `/bin/sh` por padrão, o que em alguns sistemas aponta para outras shells que não o Bash. Isso afeta o funcionamento de algumas funções, que funcionam somente no Bash. Veja mais informações em https://github.com/funcoeszz/funcoeszz/issues/207

Este commit força que o testador seja sempre excutado usando o Bash.