### PR TITLE
Forçar o testador a usar o prefixo inline #→

### DIFF
--- a/testador/run
+++ b/testador/run
@@ -32,10 +32,10 @@ EOF
 if test $# -gt 0
 then
 	# Test specific file(s)
-	$tester --progress dot --pre-flight ". $tmp" "$@"
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$@"
 else
 	# Test all files
-	$tester --progress dot --pre-flight ". $tmp" zz*.sh
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" zz*.sh
 fi
 
 rm "$tmp"


### PR DESCRIPTION
> https://github.com/funcoeszz/funcoeszz/pull/234#issuecomment-200294407
> O novo clitest usa um outro separador para o retorno das respostas inline, trocando "#→ " por "#=> ". É o caso também de fazer a troca nos testes, ou a clitest suportará ambos separadores?

Por ora, vamos somente dizer ao clitest para usar o marcador antigo, pra não precisar atualizar todos os nossos testes. Podemos fazer isso num passo posterior.