### PR TITLE
Corrigindo declaração do delimitador de saída.

### DIFF
--- a/testador/zzcut.sh
+++ b/testador/zzcut.sh
@@ -110,6 +110,14 @@ $ zzcut	-c	d,60-,d,15-25,d,-7,d -D _	_tmp2
 _¬¹²³£¢_opqrstuvwxy_abcdefg_
 $ echo "abcde12345" | zzcut -c 1-5,5-1,10-6,6-10
 abcdeedcba5432112345
+$ echo 'nome:"jose",sobrenome:"silva",nacionalidade:"brasileira"' | zzcut -f 2,4 -d \" -D " da "
+jose da silva
+$ echo 'nome:"jose",sobrenome:"silva",nacionalidade:"brasileira"' | zzcut -f 4,4 -d \" -D ' e '
+silva e silva
+$ echo 'nome:"jose",sobrenome:"silva",nacionalidade:"brasileira"' | zzcut -f 6 -d '"'
+brasileira
+$ echo 'nome:"jose",sobrenome:"silva",nacionalidade:"brasileira"' | zzcut -c d,13-21,d,22-29 -D\"
+"sobrenome":"silva"
 $
 
 # Faxina

--- a/testador/zzcut.sh
+++ b/testador/zzcut.sh
@@ -96,17 +96,17 @@ $ zzcut	-d:	-f5-3	_tmp3
 uvwxy:pqrst:klmno
 $ zzcut	-d:	-f-3,12-	_tmp3
 abcde:fghij:klmno:nµ·§¬:¹²³£¢
-$ zzcut	-d:	-f	-3,6,7,12-	--od	zzz	_tmp3
+$ zzcut	-d:	-f	-3,6,7,12-	-D	zzz	_tmp3
 abcdezzzfghijzzzklmnozzzz0123zzz45678zzznµ·§¬zzz¹²³£¢
 $ zzcut	-v	-d:	-f-3,5-8,12-	_tmp3
 pqrst:↓→øþæ:ßðđŋħ:ł»©“”
-$ zzcut	-c	35-45,d,12-18,d,50-60	--od	.oOo.	_tmp2
+$ zzcut	-c	35-45,d,12-18,d,50-60	-D	.oOo.	_tmp2
 89€®ŧ←↓→øþæ.oOo.lmnopqr.oOo.ħł»©“”nµ·§¬
-$ zzcut	-c	1,d,10-12,d,40-50	--od	";"	_tmp2
+$ zzcut	-c	1,d,10-12,d,40-50	-D	";"	_tmp2
 a;jkl;←↓→øþæßðđŋħ
-$ zzcut	--od:	-c 2-5,d,10-12,d,40-50	_tmp2
+$ zzcut	-D:	-c 2-5,d,10-12,d,40-50	_tmp2
 bcde:jkl:←↓→øþæßðđŋħ
-$ zzcut	-c	d,60-,d,15-25,d,-7,d --od _	_tmp2
+$ zzcut	-c	d,60-,d,15-25,d,-7,d -D _	_tmp2
 _¬¹²³£¢_opqrstuvwxy_abcdefg_
 $ echo "abcde12345" | zzcut -c 1-5,5-1,10-6,6-10
 abcdeedcba5432112345

--- a/testador/zzhsort.sh
+++ b/testador/zzhsort.sh
@@ -6,7 +6,7 @@ four:quatro:4
 cinco:five:5
 $
 
-$ cat _dados.txt | zzhsort -r -d ":" --ofs _
+$ cat _dados.txt | zzhsort -r -d ":" -D _
 1_um_one
 2_two_dois
 3_tres_three
@@ -14,7 +14,7 @@ $ cat _dados.txt | zzhsort -r -d ":" --ofs _
 5_five_cinco
 $
 
-$ zzhsort --ofs "-" "1 a z x 5 o"				#→ a-o-x-z-1-5
-$ zzhsort -r -d ":" --ofs "\t" "1:a:z:x:5:o"	#→ 5	1	z	x	o	a
-$ zzhsort -r --ofs "-" "1 a z x 5 o"			#→ 5-1-z-x-o-a
+$ zzhsort -D "-" "1 a z x 5 o"				#→ a-o-x-z-1-5
+$ zzhsort -r -d ":" -D "\t" "1:a:z:x:5:o"	#→ 5	1	z	x	o	a
+$ zzhsort -r -D "-" "1 a z x 5 o"			#→ 5-1-z-x-o-a
 $ zzhsort "isso está desordenado"				#→ desordenado está isso

--- a/testador/zztranspor.sh
+++ b/testador/zztranspor.sh
@@ -13,7 +13,7 @@ $ zztranspor _numeros.txt
 1 2 3 4 5
 $
 
-$ zztabuada 3 | zztranspor --ofs '\t'
+$ zztabuada 3 | zztranspor -D '\t'
 3	3	3	3	3	3	3	3	3	3	3
 x	x	x	x	x	x	x	x	x	x	x
 0	1	2	3	4	5	6	7	8	9	10
@@ -21,7 +21,7 @@ x	x	x	x	x	x	x	x	x	x	x
 0	3	6	9	12	15	18	21	24	27	30
 $
 
-$ zztabuada 7 | zztranspor -d ' x ' --ofs '\t'
+$ zztabuada 7 | zztranspor -d ' x ' -D '\t'
 7	7	7	7	7	7	7	7	7	7	7
 0  = 0	1  = 7	2  = 14	3  = 21	4  = 28	5  = 35	6  = 42	7  = 49	8  = 56	9  = 63	10 = 70
 $

--- a/zz/zzcut.sh
+++ b/zz/zzcut.sh
@@ -12,7 +12,7 @@
 #
 #  -s          não emite linhas que não contenham delimitadores.
 #
-#  --od TEXTO  usa TEXTO como delimitador da saída
+#  -D TEXTO    usa TEXTO como delimitador da saída
 #              o padrão é usar o delimitador de entrada.
 #
 #  -v          Inverter o sentido, apagando as partes selecionadas.
@@ -65,6 +65,7 @@ zzcut ()
 	test -n "$1" || { zztool -e uso cut; return 1; }
 
 	local tipo range ofd codscript qtd_campos only_delim inverte sp rlm
+	local aspas=$(echo "&zwnj;" | zzunescape --html)
 	local delim=$(printf '\t')
 
 	# Opções de linha de comando
@@ -104,10 +105,11 @@ zzcut ()
 					delim="$2"
 					shift
 				fi
+				delim=$(echo "$delim" | sed 's/"/'${aspas}'/g')
 				shift
 			;;
-			--od*)
-				ofd="${1#--od}"
+			-D*)
+				ofd="${1#-D}"
 				if test -z "$ofd"
 				then
 					ofd="$2"
@@ -228,6 +230,7 @@ zzcut ()
 				;;
 				f)
 					ofd="${ofd:-$delim}"
+					ofd=$(echo "$ofd" | sed 's/"/'${aspas}'/g')
 
 					if test "$only_delim" = "1"
 					then
@@ -321,6 +324,7 @@ zzcut ()
 	fi
 
 	zztool file_stdin "$@" |
+	sed 's/"/'${aspas}'/g' |
 	case "$tipo" in
 		c)
 			sed -n "$codscript" |
@@ -349,7 +353,8 @@ zzcut ()
 						if (tsp != 1) return saida
 				}
 				$only_delim $codscript" 2>/dev/null |
-				sed "s/\(${ofd}\)\{2,\}/${ofd}/g;s/^${ofd}//;s/${ofd}$//"
+				sed "s/\(${ofd}\)\{2,\}/${ofd}/g;s/^${ofd}//;s/${ofd}$//" |
+				sed 's/'${aspas}'/"/g'
 		;;
 	esac
 }

--- a/zz/zzcut.sh
+++ b/zz/zzcut.sh
@@ -346,7 +346,7 @@ zzcut ()
 	fi
 
 	zztool file_stdin "$@" |
-	if test $((bit_aspas / 10)) -eq 1
+	if echo "$bit_aspas" | grep '^1' >/dev/null
 	then
 		sed 's/"/'${aspas}'/g'
 	else

--- a/zz/zzcut.sh
+++ b/zz/zzcut.sh
@@ -46,9 +46,9 @@
 #      zzcut -v -c 3-8 arq.txt  # Exclui do 3º ao 8º caractere
 #      zzcut -f 1,-,3  arq.txt  # 1º campo, toda linha e 3º campo
 #      zzcut -v -f 6-  arq.txt  # Exclui a partir do 6º campo
-#      zzcut -f 8,8,8 -d ";" arq.txt    # 8º campo 3 vezes. Delimitador ";"
-#      zzcut -f 10,6 -d: --od _ arq.txt # 10º e 6º campos, novo delimitador _
-#      zzcut -c 1,d,10 --od: arq.txt    # 1º e 10º caracteres. Delimitador :
+#      zzcut -f 8,8,8 -d ";" arq.txt   # 8º campo 3 vezes. Delimitador ";"
+#      zzcut -f 10,6 -d: -D _ arq.txt  # 10º e 6º campos, novo delimitador _
+#      zzcut -c 1,d,10 -D: arq.txt     # 1º e 10º caracteres. Delimitador :
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-02-09

--- a/zz/zzhsort.sh
+++ b/zz/zzhsort.sh
@@ -52,6 +52,7 @@ zzhsort ()
 				direcao="-r"
 				shift
 			;;
+			--) shift; break;;
 			-*) zztool -e uso hsort; return 1;;
 			*) break;;
 		esac

--- a/zz/zzhsort.sh
+++ b/zz/zzhsort.sh
@@ -1,9 +1,9 @@
 # ----------------------------------------------------------------------------
 # Ordenar palavras ou números horizontalmente.
 # Opções:
-#   -r                   define o sentido da ordenação reversa.
-#   -d, --fs separador   define o separador de campos na entrada.
-#   --ofs separador      define o separador de campos na saída.
+#   -r                              define o sentido da ordenação reversa.
+#   -d <sep>                        define o separador de campos na entrada.
+#   -D, --output-demilimiter <sep>  define o separador de campos na saída.
 #
 # O separador na entrada pode ser 1 ou mais caracteres ou uma ER.
 # Se não for declarado assume-se espaços em branco como separador.
@@ -35,15 +35,15 @@ zzhsort ()
 	while test "${1#-}" != "$1"
 	do
 		case "$1" in
-			-d | --fs)
+			-d)
 			# Separador de campos na entrada
 				sep="-d $2"
 				shift
 				shift
 			;;
-			--ofs)
+			-D | --output-demilimiter)
 			# Separador de campos na saída
-				ofs="--ofs $2"
+				ofs="-D $2"
 				shift
 				shift
 			;;

--- a/zz/zzhsort.sh
+++ b/zz/zzhsort.sh
@@ -15,10 +15,10 @@
 #
 # Se o separador da entrada é uma ER, é bom declarar o separador de saída.
 #
-# Uso: zzhsort [-d | --fs <separador>] [--ofs <separador>] <Texto>
+# Uso: zzhsort [-d <sep>] [-D | --output-demilimiter <sep>] <Texto>
 # Ex.: zzhsort "isso está desordenado"            # desordenado está isso
-#      zzhsort -r -d ":" --ofs "-" "1:a:z:x:5:o"  # z-x-o-a-5-1
-#      cat num.txt | zzhsort --fs '[\t:]' --ofs '\t'
+#      zzhsort -r -d ":" -D "-" "1:a:z:x:5:o"  # z-x-o-a-5-1
+#      cat num.txt | zzhsort -d '[\t:]' --output-demilimiter '\t'
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-10-07

--- a/zz/zzhsort.sh
+++ b/zz/zzhsort.sh
@@ -3,7 +3,7 @@
 # Opções:
 #   -r                              define o sentido da ordenação reversa.
 #   -d <sep>                        define o separador de campos na entrada.
-#   -D, --output-demilimiter <sep>  define o separador de campos na saída.
+#   -D, --output-delimiter <sep>  define o separador de campos na saída.
 #
 # O separador na entrada pode ser 1 ou mais caracteres ou uma ER.
 # Se não for declarado assume-se espaços em branco como separador.
@@ -15,10 +15,10 @@
 #
 # Se o separador da entrada é uma ER, é bom declarar o separador de saída.
 #
-# Uso: zzhsort [-d <sep>] [-D | --output-demilimiter <sep>] <Texto>
+# Uso: zzhsort [-d <sep>] [-D | --output-delimiter <sep>] <Texto>
 # Ex.: zzhsort "isso está desordenado"            # desordenado está isso
 #      zzhsort -r -d ":" -D "-" "1:a:z:x:5:o"  # z-x-o-a-5-1
-#      cat num.txt | zzhsort -d '[\t:]' --output-demilimiter '\t'
+#      cat num.txt | zzhsort -d '[\t:]' --output-delimiter '\t'
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-10-07
@@ -41,7 +41,7 @@ zzhsort ()
 				shift
 				shift
 			;;
-			-D | --output-demilimiter)
+			-D | --output-delimiter)
 			# Separador de campos na saída
 				ofs="-D $2"
 				shift

--- a/zz/zztranspor.sh
+++ b/zz/zztranspor.sh
@@ -1,8 +1,8 @@
 # ----------------------------------------------------------------------------
 # Trocar linhas e colunas de um arquivo, fazendo uma simples transposição.
 # Opções:
-#   -d, --fs separador   define o separador de campos na entrada.
-#   --ofs separador      define o separador de campos na saída.
+#   -d <sep>                        define o separador de campos na entrada.
+#   -D, --output-demilimiter <sep>  define o separador de campos na saída.
 #
 # O separador na entrada pode ser 1 ou mais caracteres ou uma ER.
 # Se não for declarado assume-se espaços em branco como separador.
@@ -14,7 +14,7 @@
 #
 # Se o separador da entrada é uma ER, é bom declarar o separador de saída.
 #
-# Uso: zztranspor [-d | --fs <separador>] [--ofs <separador>] <arquivo>
+# Uso: zztranspor [-d <separador>] [-D <separador>] <arquivo>
 # Ex.: zztranspor -d ":" --ofs "-" num.txt
 #      sed -n '2,5p' num.txt | zztranspor --fs '[\t:]' --ofs '\t'
 #
@@ -33,13 +33,13 @@ zztranspor ()
 	while test "${1#-}" != "$1"
 	do
 		case "$1" in
-			-d | --fs)
+			-d)
 			# Separador de campos no arquivo de entrada
 				sep="$2"
 				shift
 				shift
 			;;
-			--ofs)
+			-D | --output-demilimiter)
 			# Separador de campos na saída
 				ofs="$2"
 				shift

--- a/zz/zztranspor.sh
+++ b/zz/zztranspor.sh
@@ -2,7 +2,7 @@
 # Trocar linhas e colunas de um arquivo, fazendo uma simples transposição.
 # Opções:
 #   -d <sep>                        define o separador de campos na entrada.
-#   -D, --output-demilimiter <sep>  define o separador de campos na saída.
+#   -D, --output-delimiter <sep>  define o separador de campos na saída.
 #
 # O separador na entrada pode ser 1 ou mais caracteres ou uma ER.
 # Se não for declarado assume-se espaços em branco como separador.
@@ -14,8 +14,8 @@
 #
 # Se o separador da entrada é uma ER, é bom declarar o separador de saída.
 #
-# Uso: zztranspor [-d <sep>] [-D | --output-demilimiter <sep>] <arquivo>
-# Ex.: zztranspor -d ":" --output-demilimiter "-" num.txt
+# Uso: zztranspor [-d <sep>] [-D | --output-delimiter <sep>] <arquivo>
+# Ex.: zztranspor -d ":" --output-delimiter "-" num.txt
 #      sed -n '2,5p' num.txt | zztranspor -d '[\t:]' -D '\t'
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
@@ -39,7 +39,7 @@ zztranspor ()
 				shift
 				shift
 			;;
-			-D | --output-demilimiter)
+			-D | --output-delimiter)
 			# Separador de campos na saída
 				ofs="$2"
 				shift

--- a/zz/zztranspor.sh
+++ b/zz/zztranspor.sh
@@ -14,9 +14,9 @@
 #
 # Se o separador da entrada é uma ER, é bom declarar o separador de saída.
 #
-# Uso: zztranspor [-d <separador>] [-D <separador>] <arquivo>
-# Ex.: zztranspor -d ":" --ofs "-" num.txt
-#      sed -n '2,5p' num.txt | zztranspor --fs '[\t:]' --ofs '\t'
+# Uso: zztranspor [-d <sep>] [-D | --output-demilimiter <sep>] <arquivo>
+# Ex.: zztranspor -d ":" --output-demilimiter "-" num.txt
+#      sed -n '2,5p' num.txt | zztranspor -d '[\t:]' -D '\t'
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-09-03


### PR DESCRIPTION
As funções ``` zzcut ```, ``` zzhsort ``` e ``` zztranspor ``` tem opções de delimitador de saída declarado de forma pouco usual como ``` --od ``` e ``` --ofs ```, e também de entrada ``` --fs ```.
Fato comentado pelo @aureliojargas em https://github.com/funcoeszz/funcoeszz/commit/ec80447488b32b2e6e623b614aaf0f8dc357722f#commitcomment-17344911

Então elimina-se a opção de delimitador entrada ``` --fs ``` e muda-se as opções de  delimitador de saída de  ``` --od ``` e ``` --ofs ``` para  ``` -D ``` e ``` --output-demilimiter ```.