### PR TITLE
zztestar: Suporte ao formato "0000.0000.0000" no Mac Address.

### DIFF
--- a/testador/zztestar.sh
+++ b/testador/zztestar.sh
@@ -67,14 +67,14 @@ $ zztestar ip6 fee::2; echo $?	#→ 0
 # mac
 $ zztestar mac 00:19:B9:FB:E2:57; echo $?	#→ 0
 $ zztestar mac 00-88-14-4D-4C-FB; echo $?	#→ 0
-$ zztestar mac 00:1D:7D:B2:34:F9; echo $?	#→ 0
-$ zztestar mac 00-0C-6E-3C-D1-6D; echo $?	#→ 0
+$ zztestar mac 00:1D-7D:B2-34:F9; echo $?	#→ 1
+$ zztestar mac 00-0C:6E-3C:D1-6D; echo $?	#→ 1
 $ zztestar mac 84B8.0243.E870; echo $?	#→ 0
-$ zztestar mac A866.7F77.D87B; echo $?	#→ 0
+$ zztestar mac A866.7F77:D87B; echo $?	#→ 1
 $ zztestar mac F027.655B.41D1; echo $?	#→ 0
-$ zztestar mac 9CD9.1702.E000; echo $?	#→ 0
-$ zztestar mac 1cc1.de97.2389; echo $?	#→ 0
-$ zztestar mac E891.20BD.EBC8; echo $?	#→ 0
+$ zztestar mac 9CD9-1702.E000; echo $?	#→ 1
+$ zztestar mac 1cc1.di97.2389; echo $?	#→ 1
+$ zztestar mac E89120BDEBC8; echo $?	#→ 1
 
 # data
 $ zztestar data 31/12/2010; echo $?	#→ 0

--- a/testador/zztestar.sh
+++ b/testador/zztestar.sh
@@ -69,6 +69,12 @@ $ zztestar mac 00:19:B9:FB:E2:57; echo $?	#→ 0
 $ zztestar mac 00-88-14-4D-4C-FB; echo $?	#→ 0
 $ zztestar mac 00:1D:7D:B2:34:F9; echo $?	#→ 0
 $ zztestar mac 00-0C-6E-3C-D1-6D; echo $?	#→ 0
+$ zztestar mac 84B8.0243.E870; echo $?	#→ 0
+$ zztestar mac A866.7F77.D87B; echo $?	#→ 0
+$ zztestar mac F027.655B.41D1; echo $?	#→ 0
+$ zztestar mac 9CD9.1702.E000; echo $?	#→ 0
+$ zztestar mac 1cc1.de97.2389; echo $?	#→ 0
+$ zztestar mac E891.20BD.EBC8; echo $?	#→ 0
 
 # data
 $ zztestar data 31/12/2010; echo $?	#→ 0

--- a/zz/zztestar.sh
+++ b/zz/zztestar.sh
@@ -184,7 +184,8 @@ zztestar ()
 		mac)
 			# Testa se $2 tem um formato de MAC válido
 			# O MAC poderá ser nos formatos 00:00:00:00:00:00, 00-00-00-00-00-00 ou 0000.0000.0000
-			echo "$2" | grep '\([0-9A-Fa-f]\{2\}[:-]\)\{5\}[0-9A-Fa-f]\{2\}' >/dev/null && return 0
+			echo "$2" | grep '\([0-9A-Fa-f]\{2\}-\)\{5\}[0-9A-Fa-f]\{2\}' >/dev/null && return 0
+			echo "$2" | grep '\([0-9A-Fa-f]\{2\}:\)\{5\}[0-9A-Fa-f]\{2\}' >/dev/null && return 0
 			echo "$2" | grep '\([0-9A-Fa-f]\{4\}\.\)\{2\}[0-9A-Fa-f]' >/dev/null && return 0
 
 			test -n "$erro" && zztool erro "MAC address inválido '$2'"

--- a/zz/zztestar.sh
+++ b/zz/zztestar.sh
@@ -184,9 +184,9 @@ zztestar ()
 		mac)
 			# Testa se $2 tem um formato de MAC válido
 			# O MAC poderá ser nos formatos 00:00:00:00:00:00, 00-00-00-00-00-00 ou 0000.0000.0000
-			echo "$2" | grep '\([0-9A-Fa-f]\{2\}-\)\{5\}[0-9A-Fa-f]\{2\}' >/dev/null && return 0
-			echo "$2" | grep '\([0-9A-Fa-f]\{2\}:\)\{5\}[0-9A-Fa-f]\{2\}' >/dev/null && return 0
-			echo "$2" | grep '\([0-9A-Fa-f]\{4\}\.\)\{2\}[0-9A-Fa-f]' >/dev/null && return 0
+			echo "$2" | egrep '^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$' >/dev/null && return 0
+			echo "$2" | egrep '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' >/dev/null && return 0
+			echo "$2" | egrep '^([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}$' >/dev/null && return 0
 
 			test -n "$erro" && zztool erro "MAC address inválido '$2'"
 			return 1

--- a/zz/zztestar.sh
+++ b/zz/zztestar.sh
@@ -183,8 +183,9 @@ zztestar ()
 
 		mac)
 			# Testa se $2 tem um formato de MAC válido
-			# O MAC poderá ser nos formatos 00:00:00:00:00:00 ou 00-00-00-00-00-00
+			# O MAC poderá ser nos formatos 00:00:00:00:00:00, 00-00-00-00-00-00 ou 0000.0000.0000
 			echo "$2" | grep '\([0-9A-Fa-f]\{2\}[:-]\)\{5\}[0-9A-Fa-f]\{2\}' >/dev/null && return 0
+			echo "$2" | grep '\([0-9A-Fa-f]\{4\}\.\)\{2\}[0-9A-Fa-f]' >/dev/null && return 0
 
 			test -n "$erro" && zztool erro "MAC address inválido '$2'"
 			return 1


### PR DESCRIPTION
Alteração feita conforme descrito em:
- http://www.cisco.com/c/en/us/td/docs/net_mgmt/cisco_secure_access_control_server_for_windows/4-2/configuration/guide/acs42_config_guide/noagent.html#wp1017547
- https://en.wikipedia.org/wiki/MAC_address#Notational_conventions