### PR TITLE
zzfatorar: Deixando de usar cache externo.

### DIFF
--- a/testador/zzfatorar.sh
+++ b/testador/zzfatorar.sh
@@ -31,4 +31,4 @@ $ zzfatorar 56877
 $
 
 $ zzfatorar 167                         #→ 167 é um número primo.
-zzfatorar 1871                          #→ 1871 é um número primo.
+$ zzfatorar 1871                        #→ 1871 é um número primo.

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -1,15 +1,13 @@
 # ----------------------------------------------------------------------------
 # Fatora um número em fatores primos.
 # Com as opções:
-#   --atualiza: atualiza o cache com 10 mil primos (padrão e rápida).
-#   --atualiza-1m: atualiza o cache com 1 milhão de primos (mais lenta).
 #   --bc: saída apenas da expressão, que pode ser usado no bc, awk ou etc.
 #   --no-bc: saída apenas do fatoramento.
 #    por padrão exibe tanto o fatoramento como a expressão.
 #
 # Se o número for primo, é exibido a mensagem apenas.
 #
-# Uso: zzfatorar [--atualiza|--atualiza-1m] [--bc|--no-bc] <número>
+# Uso: zzfatorar [--bc | --no-bc] <número>
 # Ex.: zzfatorar 1458
 #      zzfatorar --bc 1296
 #
@@ -35,17 +33,12 @@ zzfatorar ()
 	while  test "${1#-}" != "$1"
 	do
 		case "$1" in
-		'--atualiza')
-			# Força atualizar o cache
-			zztool atualiza fatorar
-			shift
-		;;
-		'--bc')
+		--bc)
 			# Apenas sai a expressão matemática que pode ser usado no bc ou awk
 			test "$bc" -eq 0 && bc=1
 			shift
 		;;
-		'--no-bc')
+		--no-bc)
 			# Apenas sai a fatoração
 			test "$bc" -eq 0 && bc=2
 			shift
@@ -127,4 +120,7 @@ zzfatorar ()
 			echo "$1 = $saida"
 		fi
 	fi
+
+	# Limpeza
+	rm -f "$cache"
 }

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -73,8 +73,9 @@ zzfatorar ()
 			while read linha
 			do
 				zzdivisores $linha |
-				awk 'NF==2{print $2}'
-			done > "$cache"
+				awk 'NF==2 {print $2}'
+			done |
+			sort -n > "$cache"
 		fi
 
 		# Se o número fornecido for primo, retorna-o e sai

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -17,19 +17,18 @@
 # Desde: 2013-03-14
 # Versão: 4
 # Licença: GPL
-# Requisitos: zzjuntalinhas
+# Requisitos: zzjuntalinhas zzdivisores
 # Nota: opcional factor
 # ----------------------------------------------------------------------------
 zzfatorar ()
 {
 	zzzz -h fatorar "$1" && return
 
-	local url='https://raw.githubusercontent.com/funcoeszz/funcoeszz/master/local/zzfatorar.txt'
 	local cache=$(zztool cache fatorar)
 	local linha_atual=1
 	local primo_atual=2
 	local bc=0
-	local num_atual saida tamanho indice
+	local num_atual saida tamanho indice linha
 
 	test -n "$1" || { zztool -e uso fatorar; return 1; }
 
@@ -64,10 +63,18 @@ zzfatorar ()
 			# Se existe o camando factor usa-o
 			factor $1 | sed 's/.*: //g' | awk '{for(i=1;i<=NF;i++) print $i }' | uniq > "$cache"
 			primo_atual=$(head -n 1 "$cache")
-		elif ! test -s "$cache"
-		then
-			# Se o cache está vazio, baixa listagem da Internet
-			zztool dump "$url" | awk '{for(i=1;i<=NF;i++) print $i }' > "$cache"
+		else
+			# Aqui lista todos os divisores do número informado não considerando o 1
+			# E descobre entre os divisores, quem é primo usando zzdivisores novamente.
+			# Aqueles que tiverem apenas 2 divisores (primos) são mantidos, além do próprio número.
+			zzdivisores $1 |
+			tr ' ' '\n' |
+			sed '1d; $!{ /.\{1,\}[024568]$/d; }' |
+			while read linha
+			do
+				zzdivisores $linha |
+				awk 'NF==2{print $2}'
+			done > "$cache"
 		fi
 
 		# Se o número fornecido for primo, retorna-o e sai

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -17,8 +17,8 @@
 # Desde: 2013-03-14
 # Versão: 4
 # Licença: GPL
-# Requisitos: zzjuntalinhas zzdos2unix
-# Nota: opcional 7z factor
+# Requisitos: zzjuntalinhas
+# Nota: opcional factor
 # ----------------------------------------------------------------------------
 zzfatorar ()
 {
@@ -41,23 +41,6 @@ zzfatorar ()
 			zztool atualiza fatorar
 			shift
 		;;
-#		'--atualiza-1m')
-#			# Atualiza o cache com uma listagem com 1 milhão de números primos.
-#			# É um processo bem mais lento, devendo ser usado quando o cache normal não atende.
-#			rm -f "$cache"
-#			if which 7z >/dev/null 2>&1 && ! which factor >/dev/null 2>&1
-#			then
-#				zztool eco "Atualizando cache."
-#				wget -q http://www.primos.mat.br/dados/50M_part1.7z -O /tmp/primos.7z
-#				7z e /tmp/primos.7z >/dev/null 2>&1
-#				rm -f /tmp/primos.7z
-#				awk '{for(i=1;i<=NF;i++) print $i }' 50M_part1.txt > "$cache"
-#				rm -f 50M_part1.txt
-#				zzdos2unix "$cache" >/dev/null 2>&1
-#				zztool eco "Cache atualizado."
-#			fi
-#			shift
-#		;;
 		'--bc')
 			# Apenas sai a expressão matemática que pode ser usado no bc ou awk
 			test "$bc" -eq 0 && bc=1

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -64,8 +64,7 @@ zzfatorar ()
 			sed '1d; $!{ /.\{1,\}[024568]$/d; }' |
 			while read linha
 			do
-				zzdivisores $linha |
-				awk 'NF==2 {print $2}'
+				zzdivisores $linha | awk 'NF==2 {print $2}'
 			done > "$cache"
 		fi
 		primo_atual=$(head -n 1 "$cache")
@@ -82,6 +81,7 @@ zzfatorar ()
 		do
 
 			# Repetindo a divisão pelo número primo atual, enquanto for exato
+			# e ecoando a fatoração formatada
 			while test $((${num_atual} % ${primo_atual})) -eq 0
 			do
 				test "$bc" != "1" && printf "%${tamanho}s | %s\n" ${num_atual} ${primo_atual}
@@ -90,7 +90,8 @@ zzfatorar ()
 				test "$bc" != "1" -a "${num_atual}" = "1" && { printf "%${tamanho}s |\n" 1; break; }
 			done
 
-			# Se o número atual é primo
+			# Se o número atual é primo finaliza a fatoração
+			# ecoando os 2 últimos elementos
 			grep "^${num_atual}$" ${cache} > /dev/null
 			if test "$?" = "0"
 			then
@@ -103,7 +104,7 @@ zzfatorar ()
 				break
 			fi
 
-			# Definindo o número primo a ser usado
+			# Definindo o próximo número primo a ser usado
 			if test "${num_atual}" != "1"
 			then
 				linha_atual=$((${linha_atual} + 1))
@@ -114,8 +115,15 @@ zzfatorar ()
 
 		if test "$bc" != "2"
 		then
-			saida=$(echo "$saida " | sed 's/ /&\
-/g' | sed '/^ *$/d;s/^ *//g' | uniq -c | awk '{ if ($1==1) {print $2} else {print $2 "^" $1} }' | zzjuntalinhas -d ' * ')
+			# Formatando a fórmula ao final da fatoração
+			saida=$(
+				echo "$saida " |
+				tr ' ' '\n' |
+				sed '/^ *$/d;s/^ *//g' |
+				uniq -c |
+				awk '{ if ($1==1) {print $2} else {print $2 "^" $1} }' |
+				zzjuntalinhas -d ' * '
+			)
 			test "$bc" -eq "1" || echo
 			echo "$1 = $saida"
 		fi

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -1,5 +1,4 @@
 # ----------------------------------------------------------------------------
-# http://www.primos.mat.br
 # Fatora um número em fatores primos.
 # Com as opções:
 #   --atualiza: atualiza o cache com 10 mil primos (padrão e rápida).
@@ -16,7 +15,7 @@
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-14
-# Versão: 3
+# Versão: 4
 # Licença: GPL
 # Requisitos: zzjuntalinhas zzdos2unix
 # Nota: opcional 7z factor
@@ -25,7 +24,7 @@ zzfatorar ()
 {
 	zzzz -h fatorar "$1" && return
 
-	local url='http://www.primos.mat.br/primeiros_10000_primos.txt'
+	local url='https://raw.githubusercontent.com/funcoeszz/funcoeszz/master/local/zzfatorar.txt'
 	local cache=$(zztool cache fatorar)
 	local linha_atual=1
 	local primo_atual=2
@@ -42,23 +41,23 @@ zzfatorar ()
 			zztool atualiza fatorar
 			shift
 		;;
-		'--atualiza-1m')
-			# Atualiza o cache com uma listagem com 1 milhão de números primos.
-			# É um processo bem mais lento, devendo ser usado quando o cache normal não atende.
-			rm -f "$cache"
-			if which 7z >/dev/null 2>&1 && ! which factor >/dev/null 2>&1
-			then
-				zztool eco "Atualizando cache."
-				wget -q http://www.primos.mat.br/dados/50M_part1.7z -O /tmp/primos.7z
-				7z e /tmp/primos.7z >/dev/null 2>&1
-				rm -f /tmp/primos.7z
-				awk '{for(i=1;i<=NF;i++) print $i }' 50M_part1.txt > "$cache"
-				rm -f 50M_part1.txt
-				zzdos2unix "$cache" >/dev/null 2>&1
-				zztool eco "Cache atualizado."
-			fi
-			shift
-		;;
+#		'--atualiza-1m')
+#			# Atualiza o cache com uma listagem com 1 milhão de números primos.
+#			# É um processo bem mais lento, devendo ser usado quando o cache normal não atende.
+#			rm -f "$cache"
+#			if which 7z >/dev/null 2>&1 && ! which factor >/dev/null 2>&1
+#			then
+#				zztool eco "Atualizando cache."
+#				wget -q http://www.primos.mat.br/dados/50M_part1.7z -O /tmp/primos.7z
+#				7z e /tmp/primos.7z >/dev/null 2>&1
+#				rm -f /tmp/primos.7z
+#				awk '{for(i=1;i<=NF;i++) print $i }' 50M_part1.txt > "$cache"
+#				rm -f 50M_part1.txt
+#				zzdos2unix "$cache" >/dev/null 2>&1
+#				zztool eco "Cache atualizado."
+#			fi
+#			shift
+#		;;
 		'--bc')
 			# Apenas sai a expressão matemática que pode ser usado no bc ou awk
 			test "$bc" -eq 0 && bc=1

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -62,7 +62,6 @@ zzfatorar ()
 		then
 			# Se existe o camando factor usa-o
 			factor $1 | sed 's/.*: //g' | awk '{for(i=1;i<=NF;i++) print $i }' | uniq > "$cache"
-			primo_atual=$(head -n 1 "$cache")
 		else
 			# Aqui lista todos os divisores do número informado não considerando o 1
 			# E descobre entre os divisores, quem é primo usando zzdivisores novamente.
@@ -74,9 +73,9 @@ zzfatorar ()
 			do
 				zzdivisores $linha |
 				awk 'NF==2 {print $2}'
-			done |
-			sort -n > "$cache"
+			done > "$cache"
 		fi
+		primo_atual=$(head -n 1 "$cache")
 
 		# Se o número fornecido for primo, retorna-o e sai
 		grep "^${1}$" ${cache} > /dev/null


### PR DESCRIPTION
O site original mudou o foco e não há mais assunto relacionado a matemática.
Para que a função não perca a funcionalidade no Mac, o uso de um arquivo externo para formar o cache foi trocado pelo uso da função ``` zzdivisores ```.