### PR TITLE
zzdicasl e zztradutor: Trocando zztool 'texto_em_iso' por 'zzutf8'.

### DIFF
--- a/zz/zzdicasl.sh
+++ b/zz/zzdicasl.sh
@@ -9,8 +9,9 @@
 #
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-08-08
-# Versão: 1
+# Versão: 2
 # Licença: GPL
+# Requisitos: zzutf8
 # ----------------------------------------------------------------------------
 zzdicasl ()
 {
@@ -31,7 +32,7 @@ zzdicasl ()
 	# Faz a consulta e filtra o resultado
 	zztool eco "$url"
 	zztool source "$url" |
-		zztool texto_em_iso |
+		zzutf8 |
 		grep -i $opcao_grep "$*" |
 		sed -n 's@^<LI><A HREF=/arquivo/\([^>]*\)> *\([^ ].*\)</A>@\1@p'
 }

--- a/zz/zztradutor.sh
+++ b/zz/zztradutor.sh
@@ -25,9 +25,9 @@
 #
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-09-02
-# Versão: 12
+# Versão: 13
 # Licença: GPLv2
-# Requisitos: zzxml zzplay zzunescape
+# Requisitos: zzxml zzplay zzunescape zzutf8
 # ----------------------------------------------------------------------------
 zztradutor ()
 {
@@ -53,7 +53,8 @@ zztradutor ()
 			zztool source "$url" |
 			zzxml --tag option |
 			sed -n '/<option value=af>/,/<option value=yi>/p' |
-			zztool texto_em_iso | sort -u |
+			zzutf8 |
+			sort -u |
 			sed 's/.*value=\([^>]*\)>\([^<]*\)<.*/\1: \2/g;s/zh-CN/cn/g' |
 			grep ${2:-:}
 			return
@@ -77,7 +78,7 @@ zztradutor ()
 	# Baixa a URL, coloca cada tag em uma linha, pega a linha desejada
 	# e limpa essa linha para estar somente o texto desejado.
 	zztool source -u "Mozilla/5.0" "$url?tr=$lang_de&hl=$lang_para&text=$padrao" 2>/dev/null |
-		zztool texto_em_iso |
+		zzutf8 |
 		zzxml --tidy |
 		sed -n '/id=result_box/,/<\/div>/p' |
 		zzxml --untag |


### PR DESCRIPTION
A troca de ``` zztool texto_em_iso ``` por ``` zzutf8 ``` visa deixar que a função analise a entrada e a converta conforme a necessidade, e não um passo obrigatório sempre.
Algumas distros conforme o locale tem uma saída de ``` encoding ``` comprometida com a forma anterior, e o uso da ``` zzutf8 ``` deixa-a mais portável.