### PR TITLE
zzlinuxnews: Nova URL para Linux Today

### DIFF
--- a/zz/zzlinuxnews.sh
+++ b/zz/zzlinuxnews.sh
@@ -42,7 +42,7 @@ zzlinuxnews ()
 	# Linux Today
 	if zztool grep_var t "$sites"
 	then
-		url='http://linuxtoday.com/backend/biglt.rss'
+		url='http://www.linuxtoday.com/backend/biglt.rss'
 		echo
 		zztool eco "* Linux Today ($url):"
 		zzfeed -n $n "$url"


### PR DESCRIPTION
A antiga redireciona para a nova, então vamos evitar o redirecionamento.