### PR TITLE
zzzz: Agora mostra o browser padrão (lynx, links, etc)

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -880,15 +880,16 @@ zzzz ()
 			info_base=$(echo "$ZZBASE" | sed 's/ /, /g')
 
 			# Informações, uma por linha
-			zztool acha '^[^)]*)' "(script) $ZZPATH"
-			zztool acha '^[^)]*)' "( pasta) $ZZDIR"
-			zztool acha '^[^)]*)' "(versão) $ZZVERSAO ($info_utf8)"
-			zztool acha '^[^)]*)' "( cores) $info_cor"
-			zztool acha '^[^)]*)' "(   tmp) $ZZTMP"
-			zztool acha '^[^)]*)' "(bashrc) $info_instalado"
-			zztool acha '^[^)]*)' "( zshrc) $info_instalado_zsh"
-			zztool acha '^[^)]*)' "(  base) $info_base"
-			zztool acha '^[^)]*)' "(  site) $url_site"
+			zztool acha '^[^)]*)' "( script) $ZZPATH"
+			zztool acha '^[^)]*)' "(  pasta) $ZZDIR"
+			zztool acha '^[^)]*)' "( versão) $ZZVERSAO ($info_utf8)"
+			zztool acha '^[^)]*)' "(  cores) $info_cor"
+			zztool acha '^[^)]*)' "(    tmp) $ZZTMP"
+			zztool acha '^[^)]*)' "(browser) $ZZBROWSER"
+			zztool acha '^[^)]*)' "( bashrc) $info_instalado"
+			zztool acha '^[^)]*)' "(  zshrc) $info_instalado_zsh"
+			zztool acha '^[^)]*)' "(   base) $info_base"
+			zztool acha '^[^)]*)' "(   site) $url_site"
 
 			# Lista de todas as funções
 

--- a/testador/zzzz.sh
+++ b/testador/zzzz.sh
@@ -44,14 +44,15 @@ Procurando o comando uniq...
 Verificando a codificação do sistema...
 Verificando a codificação das Funções ZZ...
 $ zzzz | awk '/^\(/ {sub(/\) .*/,")"); gsub(/[0-9]*/,""); print}'
-(script)
-( pasta)
-(versão)
-( cores)
-(   tmp)
-(bashrc)
-( zshrc)
-(  base)
-(  site)
+( script)
+(  pasta)
+( versão)
+(  cores)
+(    tmp)
+(browser)
+( bashrc)
+(  zshrc)
+(   base)
+(   site)
 ((  funções disponíveis ))
 $


### PR DESCRIPTION
Pra ajudar a debugar problemas do usuário e do contêiner.

Veja o diff ignorando os espaços em branco (`diff -w`),
na verdade só foi adicionada uma única linha.