### PR TITLE
Portabilidade: comando t do sed tem que ser sozinho na linha

### DIFF
--- a/zz/zzxml.sh
+++ b/zz/zzxml.sh
@@ -215,8 +215,11 @@ zzxml ()
 			zzjuntalinhas -d "$sep" |
 			sed '
 				:ini
-				/>'$sep'*</ { s//>\
-</; t ini ;}
+				/>'$sep'*</ {
+					s//>\
+</
+					t ini
+				}
 
 				# quebra linha na abertura da tag
 				s/</\


### PR DESCRIPTION
Senão dá erro no BSD.

Acabei de adicionar uma observação sobre isso lá na wiki:
https://github.com/funcoeszz/funcoeszz/wiki/Portabilidade