### PR TITLE
Isola resultado da zzxml --indent num arquivo

### DIFF
--- a/testador/zzlblank.sh
+++ b/testador/zzlblank.sh
@@ -7,7 +7,7 @@ $ sed -n 3,8p zzxml.in.xml | zzlblank
 <escape>&quot;&amp;&apos;&lt;&gt;</escape>
 $
 
-$ zzxml --indent zzxml.in.xml | sed '1d;$d' | zzlblank
+$ cat zzxml.out.indent.xml | sed '1d;$d' | zzlblank
 <section>
     <title>
         Título
@@ -30,7 +30,7 @@ $ zzxml --indent zzxml.in.xml | sed '1d;$d' | zzlblank
 </section>
 $
 
-$ zzxml --indent zzxml.in.xml | sed -n '3,20p' | zzlblank
+$ cat zzxml.out.indent.xml | sed -n '3,20p' | zzlblank
 <title>
     Título
 </title>
@@ -51,7 +51,7 @@ $ zzxml --indent zzxml.in.xml | sed -n '3,20p' | zzlblank
 </escape>
 $
 
-$ zzxml --indent zzxml.in.xml | sed -n '3,20p' | zzlblank -t
+$ cat zzxml.out.indent.xml | sed -n '3,20p' | zzlblank -t
 <title>
 	Título
 </title>
@@ -72,7 +72,7 @@ $ zzxml --indent zzxml.in.xml | sed -n '3,20p' | zzlblank -t
 </escape>
 $
 
-$ zzxml --indent zzxml.in.xml | sed -n '6,20p' | zzlblank 12
+$ cat zzxml.out.indent.xml | sed -n '6,20p' | zzlblank 12
 <img src="foo.png" />
 <para>
             Meu parágrafo, com 

--- a/testador/zzxml.out.indent.xml
+++ b/testador/zzxml.out.indent.xml
@@ -1,0 +1,22 @@
+<xml>
+	<section>
+		<title>
+			Título
+		</title>
+		<img src="foo.png" />
+		<para>
+			Meu parágrafo, com 
+			<strong>
+				negrito
+			</strong>
+			e 
+			<em>
+				itálico
+			</em>
+			.	
+		</para>
+		<escape>
+			&quot;&amp;&apos;&lt;&gt;
+		</escape>
+	</section>
+</xml>

--- a/testador/zzxml.sh
+++ b/testador/zzxml.sh
@@ -64,58 +64,12 @@ $
 #----------------------------------------------------------------------
 # --indent: Formata o XML, com indent (implica --tidy)
 
-$ zzxml --indent zzxml.in.xml 
-<xml>
-	<section>
-		<title>
-			Título
-		</title>
-		<img src="foo.png" />
-		<para>
-			Meu parágrafo, com 
-			<strong>
-				negrito
-			</strong>
-			e 
-			<em>
-				itálico
-			</em>
-			.	
-		</para>
-		<escape>
-			&quot;&amp;&apos;&lt;&gt;
-		</escape>
-	</section>
-</xml>
-$
+$ zzxml --indent zzxml.in.xml     #→ --file zzxml.out.indent.xml
 
 #----------------------------------------------------------------------
 # --indent com um XML sem quebras de linha
 
-$ zzxml --tidy zzxml.in.xml | tr -d '\n' | zzxml --indent 
-<xml>
-	<section>
-		<title>
-			Título
-		</title>
-		<img src="foo.png" />
-		<para>
-			Meu parágrafo, com 
-			<strong>
-				negrito
-			</strong>
-			e 
-			<em>
-				itálico
-			</em>
-			.	
-		</para>
-		<escape>
-			&quot;&amp;&apos;&lt;&gt;
-		</escape>
-	</section>
-</xml>
-$
+$ zzxml --tidy zzxml.in.xml | tr -d '\n' | zzxml --indent  #→ --file zzxml.out.indent.xml
 
 #----------------------------------------------------------------------
 # --notag NOME: Remove uma tag e seu conteúdo (implica --tidy)


### PR DESCRIPTION
Isso torna mais robustos os testes da zzlblank, que usa este conteúdo para seus
próprios testes.

Como estava, qualquer falha de comportamento na zzxml também quebrava os testes
da zzlblank. Agora ambos rodam de maneira independente.