### PR TITLE
Usa dumb-init para capturar sinais (Ctrl-C)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y bc curl lynx links && \
     rm -rf /var/lib/apt/lists/*
 
+# Using dumb-init to catch user signals https://github.com/funcoeszz/funcoeszz/issues/374
+RUN curl -fsSL https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 > /dumb-init && \
+    chmod +x /dumb-init
+
 ENV PATH=/app:$PATH \
     ZZPATH=/app/funcoeszz \
     ZZDIR=/app/zz \
@@ -20,5 +24,5 @@ COPY funcoeszz /app/
 COPY zz/ /app/zz/
 WORKDIR /app
 
-ENTRYPOINT ["bash", "funcoeszz"]
+ENTRYPOINT ["/dumb-init", "--", "bash", "funcoeszz"]
 CMD ["--help"]


### PR DESCRIPTION
Para poder dar um Ctrl-C durante a execução do contêiner, para interromper
imediatamente a função.

Sem isso, sinais como o Ctrl-C são ignorados.

Fixes #374