### PR TITLE
Executar o testador a partir de qualquer pasta

### DIFF
--- a/testador/run
+++ b/testador/run
@@ -12,6 +12,8 @@ zz_root=$(cd "$script_dir"; cd ..; pwd)  # handles absolute and relative
 tmp='./run.tmp'
 tester='bash clitest'
 
+cd "$script_dir"
+
 # Check requirements
 $tester -V > /dev/null || {
 	printf '%s\n' "Ops... Não achei o programa testador: clitest"


### PR DESCRIPTION
É chato ter que primeiro entrar na pasta do testador para poder usá-lo.

Com esta alteração, você pode chamar direto `~/funcoeszz/testador/run`, por
exemplo.

Você ainda precisa entrar na pasta primeiro se quiser usar glob para informar
mais de um arquivo para o testador. Mas os casos de uso mais comuns, de
informar apenas um arquivo, ou não informar nada para rodar todos os testes,
funcionará normalmente.