### PR TITLE
Usa zzutf8 em vez de texto_em_iso

### DIFF
--- a/zz/zzcinemais.sh
+++ b/zz/zzcinemais.sh
@@ -8,7 +8,7 @@
 #
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-08-25
-# Versão: 10
+# Versão: 11
 # Licença: GPLv2
 # Requisitos: zzecho zzjuntalinhas zztrim zzutf8 zzxml
 # Tags: cinema
@@ -23,7 +23,7 @@ zzcinemais ()
 
 	cidades=$(
 		zztool source -o "ISO-8859-1" "$url" |
-		zztool texto_em_iso |
+		zzutf8 |
 		sed -n '/cliclabeProg/,/cliclabeProg/p' |
 		zzxml --notag script --tag li |
 		zztrim |
@@ -53,9 +53,8 @@ zzcinemais ()
 	# Especificando User Agent na opçãp -u "Mozilla/5.0"
 	zzecho -N -l ciano $(echo "$cidades" | grep "^${codigo} - " | sed 's/^[0-9][0-9]* - //')
 	zztool source  -o "ISO-8859-1" -u "Mozilla/5.0" "${url}/cinema.php?cc=${codigo}" 2>/dev/null |
-	zztool texto_em_iso |
-	zzutf8 |
 	grep -E '(<td><a href|<td><small|[0-9] a [0-9])' |
+	zzutf8 |
 	zztrim |
 	sed 's/<[^>]*>//g;s/Programa.* - //' |
 	awk '{print}; NR%2==1 {print ""}' |


### PR DESCRIPTION
Veja #395, nos comentários há a explicação do porquê destas mudanças: https://github.com/funcoeszz/funcoeszz/issues/395#issuecomment-261372327.