### PR TITLE
Remove o build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Funções ZZ [![Build Status](https://travis-ci.org/funcoeszz/funcoeszz.svg?branch=master)](https://travis-ci.org/funcoeszz/funcoeszz)
+## Funções ZZ
 
 Funções ZZ é uma coletânea com mais de 180 miniaplicativos de utilidades diversas, prontos para serem usados na linha de comando de sistemas tipo UNIX (Linux, BSD, Cygwin, Mac OS X, entre outros).
 


### PR DESCRIPTION
Infelizmente, a nossa realidade é que sempre algo está quebrado, seja por problemas temporários em todos os servers envolvidos, atualizações dos sites, das ferramentas... Enfim.

Esse bagde sempre quebrado passa uma má impressão, que o software como um todo está quebrado, quando na verdade somente poucas funções estão quebradas (às vezes temporariamente).