### PR TITLE
zzxml: Prevenindo linhas 'vazias' com um espaço 'especial'.

### DIFF
--- a/zz/zzxml.sh
+++ b/zz/zzxml.sh
@@ -231,7 +231,7 @@ zzxml ()
 			zzjuntalinhas -i '^<!\[CDATA\[' -f ']]>$' -d '' |
 
 			# Remove linhas em branco (as que adicionamos)
-			sed '/^[[:blank:]]*$/d'
+			sed "/^[[:blank:]$sep]*$/d"
 		else
 			# Espaço antes do fechamento da tag (Recurso usado no script para tag não ambígua)
 			sed 's/ *>/  >/g'


### PR DESCRIPTION
Um complemento do PR #370 e em resposta ao issue #386.