### PR TITLE
zzconjugar: Restaurando data e autores originais.

### DIFF
--- a/zz/zzconjugar.sh
+++ b/zz/zzconjugar.sh
@@ -12,11 +12,12 @@
 # Ex.: zzconjugar correr
 #      zzconjugar comer sub
 #
-# Autor: Itamar <itamarnet (a) yahoo com br>
-# Desde: 2016-05-09
-# Versão: 3
+# Autor: Leslie Harlley Watter <leslie (a) watter org>
+# Desde: 2003-08-05
+# Versão: 5
 # Licença: GPL
 # Requisitos: zzalinhar zzcolunar zzjuntalinhas zzlblank zzminusculas zzsemacento zzsqueeze zztrim zzutf8 zzxml
+# Nota: Colaboração de José Inácio Coelho <jinacio (a) yahoo com>
 # ----------------------------------------------------------------------------
 zzconjugar ()
 {


### PR DESCRIPTION
Existia a função ``` zzconjuga  ``` criada em 05/08/2003 e desativada em 22/12/2010, e em 09/05/2016 foi criada a ``` zzconjugar ``` com a mesma premissa, e por descuido não foi verificada sua existência prévia.
Para corrigir a falha, seu autor e colaborador estão novamente constando no cabeçalho, e com a data de criação retroativa, e suas versões foram somadas.