### PR TITLE
shellcheck: Evita confusão com sintaxe de array

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -176,7 +176,7 @@ zztool ()
 				then
 					cat -
 				else
-					sed "s/$padrao/$esc[${ZZCODIGOCOR}m&$esc[m/g"
+					sed "s/$padrao/${esc}[${ZZCODIGOCOR}m&${esc}[m/g"
 				fi
 		;;
 		grep_var)


### PR DESCRIPTION
O shellcheck achou que `$esc[...` era a referência a um item de um array. Adicionei as chaves pra deixar claro que `$esc` é uma variável normal.