### PR TITLE
nanny: Funções que citam a si mesmas no campo Requisitos

### DIFF
--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -197,6 +197,13 @@ do
 done
 
 eco ----------------------------------------------------------------
+eco "* Funções que citam a si mesmas no campo Requisitos:"
+for f in zz/*.sh off/*.sh
+do
+ grep "^# Requisitos:.*$(basename $f .sh)" $f > /dev/null && echo $f
+done
+
+eco ----------------------------------------------------------------
 eco "* Funções com cabeçalho >78 colunas"
 for f in zz/*.sh off/*.sh
 do

--- a/zz/zzarrumanome.sh
+++ b/zz/zzarrumanome.sh
@@ -15,7 +15,7 @@
 # Desde: 2001-07-23
 # Versão: 1
 # Licença: GPL
-# Requisitos: zzarrumanome zzminusculas
+# Requisitos: zzminusculas
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzarrumanome ()


### PR DESCRIPTION
Dependências circulares definitivamente não são bem-vindas :)

O commit original desta linha da zzarrumanome (3c9d2dce) era de 2011!