### PR TITLE
nanny: Remove código não utilizado

### DIFF
--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -238,10 +238,8 @@ grep -H '^#.*	' zz/*.sh off/*.sh
 
 eco ----------------------------------------------------------------
 eco "* Funções que não usam 'zzzz -h'"
-ok="zztool"
 for f in zz/*.sh  # off/*.sh
 do
-	echo " $ok " | grep " $(basename $f) " >/dev/null && continue
 	grep 'zzzz -h ' $f >/dev/null || echo $f
 done
 


### PR DESCRIPTION
A zztool fica no core, não em zz/zztool.sh, então essa exceção pra ela não faz sentido. Ademais, faltava um `.sh` como parâmetro pro basename, então nem iria funcionar mesmo :P