### PR TITLE
Testes: Incluindo a opção de testes para funções que acessam internet.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ before_install:
   - mv clitest testador
 
 script:
-  - if test "$TRAVIS_OS_NAME" = osx;   then cd testador && ./run; fi
-  - if test "$TRAVIS_OS_NAME" = linux; then cd testador && ./run $(ls -1 zz*.sh | egrep -xv 'zz(linux|distro).sh'); fi
+  #- if test "$TRAVIS_OS_NAME" = osx;   then cd testador && ./run; fi
+  #- if test "$TRAVIS_OS_NAME" = linux; then cd testador && ./run $(ls -1 zz*.sh | egrep -xv 'zz(linux|distro).sh'); fi
+  - if test "$TRAVIS_OS_NAME" = linux; then cd testador && ./run internet_travis
   # Exclude zzlinux tests in Linux (see https://github.com/funcoeszz/funcoeszz/issues/355) 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 script:
   #- if test "$TRAVIS_OS_NAME" = osx;   then cd testador && ./run; fi
   #- if test "$TRAVIS_OS_NAME" = linux; then cd testador && ./run $(ls -1 zz*.sh | egrep -xv 'zz(linux|distro).sh'); fi
-  - if test "$TRAVIS_OS_NAME" = linux; then cd testador && ./run internet_travis
+  - if test "$TRAVIS_OS_NAME" = linux; then cd testador && ./run internet_travis; fi
   # Exclude zzlinux tests in Linux (see https://github.com/funcoeszz/funcoeszz/issues/355) 
 
 notifications:

--- a/testador/README.md
+++ b/testador/README.md
@@ -65,6 +65,24 @@ $
 ```
 
 
+Testar TODAS as funções baseadas na internet
+--------------------------------------------
+
+Para testar todas as funções que precisam acessar a internet ( e que tenham a tag internet devidamente apontada na função ), use o argumento internet
+
+```
+$ ./run internet
+Testing file zzblist.sh ..
+Testing file zzbrasileirao.sh ...
+Testing file zzcep.sh .....
+Testing file zzchavepgp.sh ....
+Testing file zzcidade.sh ......
+Testing file zzcoin.sh ....
+...
+$
+```
+
+
 
 Testar TODAS as funções
 -----------------------

--- a/testador/run
+++ b/testador/run
@@ -4,6 +4,7 @@
 # Usage:
 #   ./run zzsenha.sh zzcores.sh   # test zzsenha and zzcores
 #   ./run                         # run all tests
+#   ./run internet                # run all tests internet based
 #
 # See README.md file for instructions.
 
@@ -31,7 +32,17 @@ cat > "$tmp" <<EOF
 EOF
 
 # Note: To remove the dots ........ change 'dot' to 'none'
-if test $# -gt 0
+if test $1 = "internet"
+then
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t |
+		awk '/^zz.* internet/{sub(/zz\//,"");printf " " $1}')
+	exitcode=$?
+elif test $1 = "internet_travis"
+then
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t |
+		awk '/^zz.* internet/ && !/(zzdistro|zzlinux)\.sh/{sub("zz/","");printf " " $1}')
+	exitcode=$?
+elif test $# -gt 0
 then
 	# Test specific file(s)
 	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$@"

--- a/testador/run
+++ b/testador/run
@@ -40,7 +40,7 @@ then
 	# Test internet based files
 	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$internet"
 	exitcode=$?
-if test $1 = "internet_travis"
+elif test $1 = "internet_travis"
 then
 	# Test internet based files
 	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$internet_travis"

--- a/testador/run
+++ b/testador/run
@@ -34,11 +34,11 @@ EOF
 # Note: To remove the dots ........ change 'dot' to 'none'
 if test $1 = "internet"
 then
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t | awk '/^zz.* internet/{sub(/zz\//,"");printf " " $1}')
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $(awk '/# Tags: .*internet/{sub(/.*\//,"",FILENAME);print FILENAME}' ../zz/zz*.sh)
 	exitcode=$?
 elif test $1 = "internet_travis"
 then
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t | awk '/^zz.* internet/ && !/(zzdistro|zzlinux)\.sh/{sub(/zz\//,"");printf " " $1}')
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $(awk '/# Tags: .*internet/{sub(/.*\//,"",FILENAME);print FILENAME}' ../zz/zz*.sh | egrep -v 'zz(linux|distro).sh')
 	exitcode=$?
 elif test $# -gt 0
 then

--- a/testador/run
+++ b/testador/run
@@ -34,13 +34,11 @@ EOF
 # Note: To remove the dots ........ change 'dot' to 'none'
 if test $1 = "internet"
 then
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t |
-		awk '/^zz.* internet/{sub(/zz\//,"");printf " " $1}')
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t | awk '/^zz.* internet/{sub(/zz\//,"");printf " " $1}')
 	exitcode=$?
 elif test $1 = "internet_travis"
 then
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t |
-		awk '/^zz.* internet/ && !/(zzdistro|zzlinux)\.sh/{sub("zz/","");printf " " $1}')
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $("$zz_root"/util/metadata.sh t | awk '/^zz.* internet/ && !/(zzdistro|zzlinux)\.sh/{sub(/zz\//,"");printf " " $1}')
 	exitcode=$?
 elif test $# -gt 0
 then

--- a/testador/run
+++ b/testador/run
@@ -12,6 +12,8 @@ script_dir=$(dirname "$0")
 zz_root=$(cd "$script_dir"; cd ..; pwd)  # handles absolute and relative
 tmp='./run.tmp'
 tester='bash clitest'
+internet='zzblist.sh zzbrasileirao.sh zzcep.sh zzchavepgp.sh zzcidade.sh zzcoin.sh zzconfere.sh zzconjugar.sh zzcotacao.sh zzdefinr.sh zzdicantonimos.sh zzdicasl.sh zzdicbabylon.sh zzdicesperanto.sh zzdicjargon.sh zzdicportugues.sh zzdicsinonimos.sh zzdilbert.sh zzdistro.sh zzdolar.sh zzdominiopais.sh zzenglish.sh zzexcuse.sh zzfeed.sh zzfilme.sh zzfutebol.sh zzgeoip.sh zzglobo.sh zzgravatar.sh zzhoracerta.sh zzhoroscopo.sh zzhowto.sh zzipinternet.sh zzit.sh zzjquery.sh zzlibertadores.sh zzlinuxnews.sh zzlinux.sh zzlocale.sh zzloteria.sh zzlua.sh zzmacvendor.sh zzmariadb.sh zzminiurl.sh zznatal.sh zznerdcast.sh zznome.sh zznoticiaslinux.sh zznoticiassec.sh zzora.sh zzpais.sh zzpgsql.sh zzphp.sh zzporta.sh zzpronuncia.sh zzquimica.sh zzramones.sh zzrastreamento.sh zzrpmfind.sh zzsecurity.sh zzsheldon.sh zzsigla.sh zztempo.sh zztop.sh zztradutor.sh zztv.sh zztweets.sh zzvdp.sh zzvds.sh zzwikipedia.sh'
+internet_travis='zzblist.sh zzbrasileirao.sh zzcep.sh zzchavepgp.sh zzcidade.sh zzcoin.sh zzconfere.sh zzconjugar.sh zzcotacao.sh zzdefinr.sh zzdicantonimos.sh zzdicasl.sh zzdicbabylon.sh zzdicesperanto.sh zzdicjargon.sh zzdicportugues.sh zzdicsinonimos.sh zzdilbert.sh zzdolar.sh zzdominiopais.sh zzenglish.sh zzexcuse.sh zzfeed.sh zzfilme.sh zzfutebol.sh zzgeoip.sh zzglobo.sh zzgravatar.sh zzhoracerta.sh zzhoroscopo.sh zzhowto.sh zzipinternet.sh zzit.sh zzjquery.sh zzlibertadores.sh zzlinuxnews.sh zzlocale.sh zzloteria.sh zzlua.sh zzmacvendor.sh zzmariadb.sh zzminiurl.sh zznatal.sh zznerdcast.sh zznome.sh zznoticiaslinux.sh zznoticiassec.sh zzora.sh zzpais.sh zzpgsql.sh zzphp.sh zzporta.sh zzpronuncia.sh zzquimica.sh zzramones.sh zzrastreamento.sh zzrpmfind.sh zzsecurity.sh zzsheldon.sh zzsigla.sh zztempo.sh zztop.sh zztradutor.sh zztv.sh zztweets.sh zzvdp.sh zzvds.sh zzwikipedia.sh'
 
 cd "$script_dir"
 
@@ -32,13 +34,9 @@ cat > "$tmp" <<EOF
 EOF
 
 # Note: To remove the dots ........ change 'dot' to 'none'
-if test $1 = "internet"
+if test $1 = "internet" -o $1 = "internet_travis"
 then
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $(awk '/# Tags: .*internet/{sub(/.*\//,"",FILENAME);print FILENAME}' ../zz/zz*.sh)
-	exitcode=$?
-elif test $1 = "internet_travis"
-then
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $(awk '/# Tags: .*internet/{sub(/.*\//,"",FILENAME);print FILENAME}' ../zz/zz*.sh | egrep -v 'zz(linux|distro).sh')
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" ${!1}
 	exitcode=$?
 elif test $# -gt 0
 then

--- a/testador/run
+++ b/testador/run
@@ -38,12 +38,12 @@ EOF
 if test $1 = "internet"
 then
 	# Test internet based files
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$internet"
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $internet
 	exitcode=$?
 elif test $1 = "internet_travis"
 then
 	# Test internet based files
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$internet_travis"
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $internet_travis
 	exitcode=$?
 elif test $# -gt 0
 then

--- a/testador/run
+++ b/testador/run
@@ -12,7 +12,11 @@ script_dir=$(dirname "$0")
 zz_root=$(cd "$script_dir"; cd ..; pwd)  # handles absolute and relative
 tmp='./run.tmp'
 tester='bash clitest'
+
+# Na pasta util: $ ./metadata.sh t | sed -n '/internet/{s|.*/||;s/ .*//;p;}' | tr '\n' ' '
 internet='zzblist.sh zzbrasileirao.sh zzcep.sh zzchavepgp.sh zzcidade.sh zzcoin.sh zzconfere.sh zzconjugar.sh zzcotacao.sh zzdefinr.sh zzdicantonimos.sh zzdicasl.sh zzdicbabylon.sh zzdicesperanto.sh zzdicjargon.sh zzdicportugues.sh zzdicsinonimos.sh zzdilbert.sh zzdistro.sh zzdolar.sh zzdominiopais.sh zzenglish.sh zzexcuse.sh zzfeed.sh zzfilme.sh zzfutebol.sh zzgeoip.sh zzglobo.sh zzgravatar.sh zzhoracerta.sh zzhoroscopo.sh zzhowto.sh zzipinternet.sh zzit.sh zzjquery.sh zzlibertadores.sh zzlinuxnews.sh zzlinux.sh zzlocale.sh zzloteria.sh zzlua.sh zzmacvendor.sh zzmariadb.sh zzminiurl.sh zznatal.sh zznerdcast.sh zznome.sh zznoticiaslinux.sh zznoticiassec.sh zzora.sh zzpais.sh zzpgsql.sh zzphp.sh zzporta.sh zzpronuncia.sh zzquimica.sh zzramones.sh zzrastreamento.sh zzrpmfind.sh zzsecurity.sh zzsheldon.sh zzsigla.sh zztempo.sh zztop.sh zztradutor.sh zztv.sh zztweets.sh zzvdp.sh zzvds.sh zzwikipedia.sh'
+
+# Na pasta util: $ ./metadata.sh t | sed -n '/zz\(distro\|linux\)\.sh/d;/internet/{s|.*/||;s/ .*//;p;}' | tr '\n' ' '
 internet_travis='zzblist.sh zzbrasileirao.sh zzcep.sh zzchavepgp.sh zzcidade.sh zzcoin.sh zzconfere.sh zzconjugar.sh zzcotacao.sh zzdefinr.sh zzdicantonimos.sh zzdicasl.sh zzdicbabylon.sh zzdicesperanto.sh zzdicjargon.sh zzdicportugues.sh zzdicsinonimos.sh zzdilbert.sh zzdolar.sh zzdominiopais.sh zzenglish.sh zzexcuse.sh zzfeed.sh zzfilme.sh zzfutebol.sh zzgeoip.sh zzglobo.sh zzgravatar.sh zzhoracerta.sh zzhoroscopo.sh zzhowto.sh zzipinternet.sh zzit.sh zzjquery.sh zzlibertadores.sh zzlinuxnews.sh zzlocale.sh zzloteria.sh zzlua.sh zzmacvendor.sh zzmariadb.sh zzminiurl.sh zznatal.sh zznerdcast.sh zznome.sh zznoticiaslinux.sh zznoticiassec.sh zzora.sh zzpais.sh zzpgsql.sh zzphp.sh zzporta.sh zzpronuncia.sh zzquimica.sh zzramones.sh zzrastreamento.sh zzrpmfind.sh zzsecurity.sh zzsheldon.sh zzsigla.sh zztempo.sh zztop.sh zztradutor.sh zztv.sh zztweets.sh zzvdp.sh zzvds.sh zzwikipedia.sh'
 
 cd "$script_dir"
@@ -36,6 +40,7 @@ EOF
 # Note: To remove the dots ........ change 'dot' to 'none'
 if test $1 = "internet" -o $1 = "internet_travis"
 then
+	# Test files internet based
 	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" ${!1}
 	exitcode=$?
 elif test $# -gt 0

--- a/testador/run
+++ b/testador/run
@@ -4,7 +4,7 @@
 # Usage:
 #   ./run zzsenha.sh zzcores.sh   # test zzsenha and zzcores
 #   ./run                         # run all tests
-#   ./run internet                # run all tests internet based
+#   ./run internet                # run all internet based tests
 #
 # See README.md file for instructions.
 
@@ -13,11 +13,8 @@ zz_root=$(cd "$script_dir"; cd ..; pwd)  # handles absolute and relative
 tmp='./run.tmp'
 tester='bash clitest'
 
-# Na pasta util: $ ./metadata.sh t | sed -n '/internet/{s|.*/||;s/ .*//;p;}' | tr '\n' ' '
-internet='zzblist.sh zzbrasileirao.sh zzcep.sh zzchavepgp.sh zzcidade.sh zzcoin.sh zzconfere.sh zzconjugar.sh zzcotacao.sh zzdefinr.sh zzdicantonimos.sh zzdicasl.sh zzdicbabylon.sh zzdicesperanto.sh zzdicjargon.sh zzdicportugues.sh zzdicsinonimos.sh zzdilbert.sh zzdistro.sh zzdolar.sh zzdominiopais.sh zzenglish.sh zzexcuse.sh zzfeed.sh zzfilme.sh zzfutebol.sh zzgeoip.sh zzglobo.sh zzgravatar.sh zzhoracerta.sh zzhoroscopo.sh zzhowto.sh zzipinternet.sh zzit.sh zzjquery.sh zzlibertadores.sh zzlinuxnews.sh zzlinux.sh zzlocale.sh zzloteria.sh zzlua.sh zzmacvendor.sh zzmariadb.sh zzminiurl.sh zznatal.sh zznerdcast.sh zznome.sh zznoticiaslinux.sh zznoticiassec.sh zzora.sh zzpais.sh zzpgsql.sh zzphp.sh zzporta.sh zzpronuncia.sh zzquimica.sh zzramones.sh zzrastreamento.sh zzrpmfind.sh zzsecurity.sh zzsheldon.sh zzsigla.sh zztempo.sh zztop.sh zztradutor.sh zztv.sh zztweets.sh zzvdp.sh zzvds.sh zzwikipedia.sh'
-
-# Na pasta util: $ ./metadata.sh t | sed -n '/zz\(distro\|linux\)\.sh/d;/internet/{s|.*/||;s/ .*//;p;}' | tr '\n' ' '
-internet_travis='zzblist.sh zzbrasileirao.sh zzcep.sh zzchavepgp.sh zzcidade.sh zzcoin.sh zzconfere.sh zzconjugar.sh zzcotacao.sh zzdefinr.sh zzdicantonimos.sh zzdicasl.sh zzdicbabylon.sh zzdicesperanto.sh zzdicjargon.sh zzdicportugues.sh zzdicsinonimos.sh zzdilbert.sh zzdolar.sh zzdominiopais.sh zzenglish.sh zzexcuse.sh zzfeed.sh zzfilme.sh zzfutebol.sh zzgeoip.sh zzglobo.sh zzgravatar.sh zzhoracerta.sh zzhoroscopo.sh zzhowto.sh zzipinternet.sh zzit.sh zzjquery.sh zzlibertadores.sh zzlinuxnews.sh zzlocale.sh zzloteria.sh zzlua.sh zzmacvendor.sh zzmariadb.sh zzminiurl.sh zznatal.sh zznerdcast.sh zznome.sh zznoticiaslinux.sh zznoticiassec.sh zzora.sh zzpais.sh zzpgsql.sh zzphp.sh zzporta.sh zzpronuncia.sh zzquimica.sh zzramones.sh zzrastreamento.sh zzrpmfind.sh zzsecurity.sh zzsheldon.sh zzsigla.sh zztempo.sh zztop.sh zztradutor.sh zztv.sh zztweets.sh zzvdp.sh zzvds.sh zzwikipedia.sh'
+internet=$("$zz_root"/util/metadata.sh tags | awk '/^zz.* internet/{sub(/zz\//,"");printf " " $1}')
+internet_travis=$(echo $internet | sed 's/ zz\(distro\|linux\)\.sh//g')
 
 cd "$script_dir"
 
@@ -38,10 +35,15 @@ cat > "$tmp" <<EOF
 EOF
 
 # Note: To remove the dots ........ change 'dot' to 'none'
-if test $1 = "internet" -o $1 = "internet_travis"
+if test $1 = "internet"
 then
-	# Test files internet based
-	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" ${!1}
+	# Test internet based files
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$internet"
+	exitcode=$?
+if test $1 = "internet_travis"
+then
+	# Test internet based files
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" "$internet_travis"
 	exitcode=$?
 elif test $# -gt 0
 then


### PR DESCRIPTION
Como a maioria dos erros são de funções que fazem consulta na internet, adotamos como padrão os testes limitados as funções cuja tag esteja assinalada internet. Tornando assim os testes mais velozes para a sequência de correções necessárias de funçoes quebradas.