### PR TITLE
zzrastreamento alteracao endereco www de busca do correio

### DIFF
--- a/zz/zzrastreamento.sh
+++ b/zz/zzrastreamento.sh
@@ -18,7 +18,8 @@ zzrastreamento ()
 
 	test -n "$1" || { zztool -e uso rastreamento; return 1; }
 
-	local url='http://www2.correios.com.br/sistemas/rastreamento/resultado_semcontent.cfm?'
+	local url='https://www2.correios.com.br/sistemas/rastreamento/resultado.cfm'
+#	local url='http://www2.correios.com.br/sistemas/rastreamento/resultado_semcontent.cfm?'
 
 	# Para cada código recebido...
 	for codigo


### PR DESCRIPTION
O zzrastreamento estava com falha, abri o arquivo para tentar entender e verifiquei que o link do correio mudou. Fiz a alteração e rodou certinho.

endereço antigo:
http://www2.correios.com.br/sistemas/rastreamento/resultado_semcontent.cfm?

endereço atualizado (19/10/2019)
https://www2.correios.com.br/sistemas/rastreamento/resultado.cfm

Até o momento funcionando.