### PR TITLE
A função zzmaiores com opção -f não funcionava no meu ambiente

### DIFF
--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -68,7 +68,7 @@ zzmaiores ()
 		resultado=$(
 			find $pastas $recursivo -type f -ls |
 				tr -s ' ' |
-				zzlblank |
+				zztrim -l |
 				cut -d' ' -f7,11- |
 				sed "s/ /$tab/" |
 				sort -nr |

--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -68,6 +68,7 @@ zzmaiores ()
 		resultado=$(
 			find $pastas $recursivo -type f -ls |
 				tr -s ' ' |
+				zzlblank |
 				cut -d' ' -f7,11- |
 				sed "s/ /$tab/" |
 				sort -nr |


### PR DESCRIPTION
Isso devido à saída do comando find que coloca espaços no início de cada linha. O comando `tr -s " "` que está na função `zz maiores` transforma vários espaços em um só, mas isto significa que ainda haverá um espaço no início das linhas do comando `find`. Para resolver o problema, simplesmente adicionei um próprio comando das funcoeszz: `zzlblank`. Dessa forma, garante-se que não haverá espaços iniciais.

Para exemplificar o que estava acontecendo no meu ambiente, segue a saída do `find -ls`:

```
 13911760      8 -rw-r--r--   1 user  user      8105 Jul  4 21:41 ./arquivo1
 13913962    124 -rw-r--r--   1 user  user    125099 Jul  4 22:19 ./arquivo2
 13914195     12 -rw-r--r--   1 user  user      8923 Jul  4 21:41 ./arquivo3
 13913802     16 -rw-r--r--   1 user  user     14741 Jul  4 21:41 ./arquivo4
 13911180   1024 -rw-r--r--   1 user  user   1047576 Jul  9 14:04 ./arquivo5
`-> espaço aqui (às vezes são vários)
```

A saída incorreta do zz maiores era:

```
user 22:19 ./arquivo2
user 21:41 ./arquivo4
user 21:41 ./arquivo3
user 21:41 ./arquivo1
user 14:04 ./arquivo5
```

Ou seja, o cut se embolava com os campos. A introdução do `zzlblank` corrige isso.

Ambiente:

```
   Debian GNU/Linux 10

   find (GNU findutils) 4.6.0.225-235f
   Copyright (C) 2019 Free Software Foundation, Inc.
   License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
   This is free software: you are free to change and redistribute it.
   There is NO WARRANTY, to the extent permitted by law.

   Written by Eric B. Decker, James Youngman, and Kevin Dalley.
   Features enabled: D_TYPE O_NOFOLLOW(enabled) LEAF_OPTIMISATION FTS(FTS_CWDFD) CBO(level=2)
```