### PR TITLE
testador: nova opção 'local' para testes sem acesso à internet

### DIFF
--- a/testador/README.md
+++ b/testador/README.md
@@ -1,7 +1,7 @@
 Testador das Funções ZZ
 =======================
 
-É preciso garantir que todas as funções estejam sempre funcionando corretamente. Esta não é uma tarefa fácil, já que são mais de 150 funções ao todo, e muitas delas dependem de informações obtidas em websites, que estão em constante mudança.
+É preciso garantir que todas as funções estejam sempre funcionando corretamente. Esta não é uma tarefa fácil, já que são mais de 180 funções ao todo, e muitas delas dependem de informações obtidas em websites, que estão em constante mudança.
 
 O testador automático das Funções ZZ testa o funcionamento de cada função e avisa caso algo esteja errado. Já estão cadastrados mais de 3.000 testes!
 
@@ -65,10 +65,10 @@ $
 ```
 
 
-Testar TODAS as funções baseadas na internet
---------------------------------------------
+Testar TODAS as funções baseadas na internet (ou não)
+-----------------------------------------------------
 
-Para testar todas as funções que precisam acessar a internet ( e que tenham a tag internet devidamente apontada na função ), use o argumento internet
+Para testar todas as funções que precisam acessar a internet:
 
 ```
 $ ./run internet
@@ -82,6 +82,18 @@ Testing file zzcoin.sh ....
 $
 ```
 
+Para testar todas as funções que funcionam sem precisar de acesso à internet:
+
+```
+$ ./run local
+Testing file zzajuda.sh ...
+Testing file zzaleatorio.sh ....
+Testing file zzalfabeto.sh .....................................
+Testing file zzalinhar.sh ........
+Testing file zzansi2html.sh .......
+...
+$
+```
 
 
 Testar TODAS as funções
@@ -315,5 +327,3 @@ O script `run` é apenas um wrapper pequeno, para facilitar a chamada do testado
 O `clitest` é um projeto separado, também criado pelo Aurelio Jargas e também escrito em shell script. Para mais informações sobre o funcionamento do testador, acesse:
 
 * <https://github.com/aureliojargas/clitest>
-
-

--- a/testador/run
+++ b/testador/run
@@ -1,10 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 # run - run tests
 #
 # Usage:
 #   ./run zzsenha.sh zzcores.sh   # test zzsenha and zzcores
 #   ./run                         # run all tests
 #   ./run internet                # run all internet based tests
+#   ./run local                   # run all local tests (no internet)
 #
 # See README.md file for instructions.
 
@@ -13,10 +14,12 @@ zz_root=$(cd "$script_dir"; cd ..; pwd)  # handles absolute and relative
 tmp='./run.tmp'
 tester='bash clitest'
 
-internet=$("$zz_root"/util/metadata.sh tags | awk '/^zz.* internet/{sub(/zz\//,"");printf " " $1}')
-internet_travis=$(echo $internet | sed 's/ zz\(distro\|linux\)\.sh//g')
-
 cd "$script_dir"
+
+internet=$("$zz_root"/util/metadata.sh tags | awk '/^zz.* internet/{sub(/zz\//,"");printf $1 "\n"}')
+internet_travis=$(echo "$internet" | grep -E -v '^zz(distro|linux)\.sh$')
+all=$(ls -1 zz*.sh)
+no_internet=$(echo "$all" | grep -F -v -x -f <(echo "$internet"))
 
 # Check requirements
 $tester -V > /dev/null || {
@@ -44,6 +47,11 @@ elif test $1 = "internet_travis"
 then
 	# Test internet based files
 	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $internet_travis
+	exitcode=$?
+elif test $1 = "local"
+then
+	# Tests that do not need internet
+	$tester --inline-prefix '#→ ' --progress dot --pre-flight ". $tmp" $no_internet
 	exitcode=$?
 elif test $# -gt 0
 then


### PR DESCRIPTION
Com essa mudança, é possível rodar somente os testes que não requerem
acesso à internet. Exemplo:

    ./testador/run local