### PR TITLE
Corrige 'José' e 'Lourenço'

### DIFF
--- a/testador/zzarrumacidade.sh
+++ b/testador/zzarrumacidade.sh
@@ -60,6 +60,11 @@ $ zzarrumacidade "florianopolis"                  #→ Florianópolis
 $ zzarrumacidade "virginopolis"                   #→ Virginópolis
 $ zzarrumacidade "caparao"                        #→ Caparaó
 $ zzarrumacidade "sao Francisco"                  #→ São Francisco
+$ zzarrumacidade "sao jose"                       #→ São José
+$ zzarrumacidade "sao jose do sul"                #→ São José do Sul
+
+$ zzarrumacidade "sao lourenco"                   #→ São Lourenço
+$ zzarrumacidade "sao lourenco do oeste"          #→ São Lourenço do Oeste
 # exceção
 $ zzarrumacidade "alto caparao"                   #→ Alto Caparaó
 # ão várias vezes

--- a/zz/zzarrumacidade.sh
+++ b/zz/zzarrumacidade.sh
@@ -124,6 +124,14 @@ zzarrumacidade ()
 		s/ao /ão /g
 		s/ao$/ão/
 
+        ## Correções de nomes próprios
+        # 'jose' vira 'José'
+        s/[Jj]ose$/José/
+        s/[Jj]ose /José /
+
+        # 'lourenço' vira 'Lourenço'
+        s/enco$/enço/
+        s/enco /enço /g
 
 		### Exceções pontuais:
 


### PR DESCRIPTION
Esta mudança faz com que o zzarrumacidade corrija "jose" para "José" e "lourenco" para "Lourenço".