### PR TITLE
zzmacaddress: Incluindo o comando ip para suprir a ausência do ifconfig.

### DIFF
--- a/zz/zzmacaddress.sh
+++ b/zz/zzmacaddress.sh
@@ -5,16 +5,23 @@
 #
 # Autor: Adriano Laureano, @sl4ureano
 # Desde: 2018-10-09
-# Versão: 1
+# Versão: 2 
 # Licença: GPL
 # Tags: sistema, consulta
-# Nota: requer ifconfig
+# Nota: (ou) ip ifconfig
 # ----------------------------------------------------------------------------
 zzmacaddress ()
 {
 	zzzz -h macaddress "$1" && return
 
-	which ifconfig 1>/dev/null 2>&1 || { zztool erro "ifconfig não instalado"; return 1; }
-
-	ifconfig | sed -n '/ HW\|ether /{s/.*\(\([0-9A-Fa-f]\{2\}:\)\{5\}[0-9A-Fa-f]\{2\}\).*/\1/;p;}'
+	if which ifconfig 1>/dev/null 2>&1
+	then
+		ifconfig | sed -n '/ HW\|ether /{s/.*\(\([0-9A-Fa-f]\{2\}:\)\{5\}[0-9A-Fa-f]\{2\}\).*/\1/;p;}'
+	elif which ip 1>/dev/null 2>&1
+	then
+		ip address | awk '/ether/ {print $2}'
+	else
+		zztool erro "Necessário instalar ip ou ifconfig."
+		return 1
+	fi
 }


### PR DESCRIPTION
O comando ifconfig está presente em distribuições mais antigas, sendo substituído pelo comando ip que é mais abrangente nos sistemas atuais. Para manter uma maior compatibilidade, ao invés de substituir o comando, apenas inclui o novo comando ip para que seja funcional em sistemas antigos e atuais.