### PR TITLE
zzcotacao: Ajustando a consulta apenas para o site da Infomoney.

### DIFF
--- a/testador/zzcotacao.sh
+++ b/testador/zzcotacao.sh
@@ -1,18 +1,11 @@
-$ zzcotacao | sed 's/[0-9],[0-9]\{3\}/9.999/g;s|  n/d|9.999|g;s/[+_]/ /g;s/-/ /g;s/[0-9],[0-9]\{2\}/9.99/g;5q'
+$ zzcotacao | sed 's/[0-9],[0-9]\{3,\}/9.999/g;s/0/9.999/g;s|  n/d|9.999|g;s/[+_]/ /g;s/-//g;s/[0-9],[0-9]\{2\}/9.99/g;9q' | sed 's/  *9.999/\t9.999/g'
 Infomoney
                     Compra   Venda   Var(%)
-Dólar Comercial      9.999   9.999    9.99
-Dólar Turismo        9.999   9.999    9.99
-Dólar PTAX800        9.999   9.999    9.99
-$
-
-$ zzcotacao | sed -n '/UOL /,$ {s|[0-3][0-9]/[0-1][0-9]/[0-9]\{4\}|DATA|;s/[0-2][0-9]h[0-5][0-9]/HORA/ ;s/[0-9],[0-9]\{4\}/9.9999/g;s/[+_]/ /g;s/-/ /g;s/  *[0-9],[0-9]\{1,\}%/   9.99%/g;p;}'
-UOL   Economia
-DATA HORA
-                    Compra   Venda   Var(%)
-Dólar Comercial     9.9999  9.9999   9.99%
-Dólar Turismo       9.9999  9.9999   9.99%
-Euro                9.9999  9.9999   9.99%
-Libra               9.9999  9.9999   9.99%
-Pesos Argentino     9.9999  9.9999   9.99%
+Peso Argentino	9.999	9.999	9.999
+Dólar Australiano	9.999	9.999	9.999
+Dólar Canadense	9.999	9.999	9.999
+Franco Suíço          9.99	9.999	9.999
+Dólar Comercial	9.999	9.999	9.999
+Dólar Turismo	9.999	9.999	9.999
+Euro	9.999	9.999	9.999
 $

--- a/zz/zzcotacao.sh
+++ b/zz/zzcotacao.sh
@@ -6,7 +6,7 @@
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-19
-# Versão: 4
+# Versão: 5
 # Licença: GPL
 # Requisitos: zzjuntalinhas zzsqueeze zztrim zzunescape zzxml
 # Tags: internet, consulta
@@ -17,7 +17,7 @@ zzcotacao ()
 
 	zztool eco "Infomoney"
 	zztool source "http://www.infomoney.com.br/mercados/cambio" |
-	sed -n '/<table class="table-general">/,/<\/table>/{/table>/q;p;}' |
+	sed -n '/<thead/,/thead>/p;/<tbody/,/tbody>/{ s/ *</</g;p;}' |
 	zzjuntalinhas -i '<tr>' -f '</tr>' |
 	zzxml --untag |
 	zzsqueeze |
@@ -32,27 +32,4 @@ zzcotacao ()
 			if (NF == 5) printf "%-18s  %6s  %6s  %6s\n", $1 " " $2, $3, $4, $5
 		}
 	}'
-
-	echo
-	zztool eco "UOL - Economia"
-	# Faz a consulta e filtra o resultado
-	zztool source 'http://economia.uol.com.br/cotacoes' |
-	zzxml --tidy |
-	sed -n '/<table class="borda mod-grafico-wide quatro-colunas">/,/table>/p' |
-	zzjuntalinhas -i '<tr>' -f '</tr>' |
-	zzjuntalinhas -i '<thead>' -f '</thead>' |
-	zzjuntalinhas -i '<caption' -f 'caption>' |
-	zzxml --untag |
-	zzsqueeze |
-	zztrim |
-	sed '1s/Dólar //;s/Variação/Var(%)/;s/comercial - //;s/com\./Comercial/;s/tur\./Turismo/;s/arg\./Argentino/;/^Fonte/d;/^Veja/d' |
-		awk '
-		NR==1
-		{
-			if ( NR == 2 ) printf "%18s  %6s  %6s   %6s\n", "", $1, $2, $3
-			if ( NR >  2 ) {
-				if (NF == 4 && $2 != "n/d" && $3 != "n/d") printf "%-18s  %6s  %6s  %6s\n", $1, $2, $3, $4
-				if (NF == 5 && $3 != "n/d" && $4 != "n/d") printf "%-18s  %6s  %6s  %6s\n", $1 " " $2, $3, $4, $5
-			}
-		}'
 }


### PR DESCRIPTION
Economia UOL foi desconsiderada devido a bloqueios por excesso de uso.