### PR TITLE
zzloteria: Isolando atualização de cache.

### DIFF
--- a/zz/zzloteria.sh
+++ b/zz/zzloteria.sh
@@ -46,7 +46,7 @@ zzloteria ()
 	then
 		echo "$(zzdatafmt --iso hoje) $(zzhoramin)" > "$cache"
 		zztool source "$url" >> "$cache"
-		shift
+		return
 	else
 		unset num_con
 		test -n "$1" && tipos="$*"


### PR DESCRIPTION
Na primeira vez que a ` zzloteria ` é invocada, independente dos argumentos, o comportamento inicial era como se a ` zzloteria ` fosse executada sem argumentos, e depois cumpria o que se esperava.
Isso está ligado a atualização do cache, que pelas mudanças recentes do site de consulta, apresentam um comportamento diferente do que apresentavam antes. Então a chamada com o argumento '--atualiza' fica unicamente para atualizar o cache, sem dar prossegimento a qualquer consulta mesmo que sejam especificados nos demais argumentos.