### PR TITLE
Função nova: zzf1 - Mostra a classificação de pilotos e construtores da F1.

### DIFF
--- a/testador/zzf1.sh
+++ b/testador/zzf1.sh
@@ -1,0 +1,193 @@
+$ zzf1 -c 1978
+  Pts  Construtor       País
+   86  Team Lotus       British
+   58  Ferrari          Italian
+   53  Brabham          British
+   38  Tyrrell          British
+   24  Wolf             Canadian
+   19  Ligier           French
+   17  Fittipaldi       Brazilian
+   15  McLaren          British
+   11  Williams         British
+   11  Arrows           British
+    6  Shadow           British
+    3  Renault          French
+    1  Surtees          British
+    1  Ensign           British
+    0  ATS              Italian
+    0  Martini          French
+    0  Merzario         Italian
+    0  Theodore         Hong Kong
+    0  Hesketh          British
+
+$ zzf1 -p 1987
+  Pts  Piloto                    Construtor       País
+   73  Nelson Piquet             Williams         Brazilian
+   61  Nigel Mansell             Williams         British
+   57  Ayrton Senna              Team Lotus       Brazilian
+   46  Alain Prost               McLaren          French
+   36  Gerhard Berger            Ferrari          Austrian
+   30  Stefan Johansson          McLaren          Swedish
+   17  Michele Alboreto          Ferrari          Italian
+   16  Thierry Boutsen           Benetton         Belgian
+   12  Teo Fabi                  Benetton         Italian
+    8  Eddie Cheever             Arrows           American
+    7  Jonathan Palmer           Tyrrell          British
+    7  Satoru Nakajima           Team Lotus       Japanese
+    6  Riccardo Patrese          Brabham          Italian
+    4  Andrea de Cesaris         Brabham          Italian
+    4  Philippe Streiff          Tyrrell          French
+    3  Derek Warwick             Arrows           British
+    3  Philippe Alliot           Larrousse        French
+    2  Martin Brundle            Zakspeed         British
+    1  Ivan Capelli              March            Italian
+    1  René Arnoux               Ligier           French
+    1  Roberto Moreno            AGS              Brazilian
+    0  Yannick Dalmas            Larrousse        French
+    0  Christian Danner          Zakspeed         German
+    0  Piercarlo Ghinzani        Ligier           Italian
+    0  Pascal Fabre              AGS              French
+    0  Alessandro Nannini        Minardi          Italian
+    0  Alex Caffi                Osella           Italian
+    0  Adrián Campos             Minardi          Spanish
+    0  Franco Forini             Osella           Swiss
+    0  Stefano Modena            Brabham          Italian
+
+$ zzf1 -p 1990
+  Pts  Piloto                    Construtor       País
+   78  Ayrton Senna              McLaren          Brazilian
+   71  Alain Prost               Ferrari          French
+   43  Nelson Piquet             Benetton         Brazilian
+   43  Gerhard Berger            McLaren          Austrian
+   37  Nigel Mansell             Ferrari          British
+   34  Thierry Boutsen           Williams         Belgian
+   23  Riccardo Patrese          Williams         Italian
+   21  Alessandro Nannini        Benetton         Italian
+   13  Jean Alesi                Tyrrell          French
+    6  Ivan Capelli              Leyton House     Italian
+    6  Roberto Moreno            Euro Brun        Brazilian
+    6  Aguri Suzuki              Larrousse        Japanese
+    5  Éric Bernard              Larrousse        French
+    3  Derek Warwick             Team Lotus       British
+    3  Satoru Nakajima           Tyrrell          Japanese
+    2  Alex Caffi                Arrows           Italian
+    2  Stefano Modena            Brabham          Italian
+    1  Maurício Gugelmin         Leyton House     Brazilian
+    0  Nicola Larini             Ligier           Italian
+    0  Martin Donnelly           Team Lotus       British
+    0  Pierluigi Martini         Minardi          Italian
+    0  Gregor Foitek             Brabham          Swiss
+    0  Philippe Alliot           Ligier           French
+    0  Michele Alboreto          Arrows           Italian
+    0  Yannick Dalmas            AGS              French
+    0  Emanuele Pirro            Dallara          Italian
+    0  Andrea de Cesaris         Dallara          Italian
+    0  Paolo Barilla             Minardi          Italian
+    0  Jyrki Järvilehto          Onyx             Finnish
+    0  Bernd Schneider           Arrows           German
+
+$ zzf1 -c 2000
+  Pts  Construtor       País
+  170  Ferrari          Italian
+  162  McLaren          British
+   36  Williams         British
+   20  Benetton         Italian
+   20  BAR              British
+   17  Jordan           Irish
+    7  Arrows           British
+    6  Sauber           Swiss
+    4  Jaguar           British
+    0  Minardi          Italian
+    0  Prost            French
+
+$ zzf1 2009
+  Pts  Piloto                    Construtor       País
+   95  Jenson Button             Brawn            British
+   84  Sebastian Vettel          Red Bull         German
+   77  Rubens Barrichello        Brawn            Brazilian
+ 69.5  Mark Webber               Red Bull         Australian
+   49  Lewis Hamilton            McLaren          British
+   48  Kimi Räikkönen            Ferrari          Finnish
+ 34.5  Nico Rosberg              Williams         German
+ 32.5  Jarno Trulli              Toyota           Italian
+   26  Fernando Alonso           Renault          Spanish
+   24  Timo Glock                Toyota           German
+   22  Felipe Massa              Ferrari          Brazilian
+   22  Heikki Kovalainen         McLaren          Finnish
+   19  Nick Heidfeld             BMW Sauber       German
+   17  Robert Kubica             BMW Sauber       Polish
+    8  Giancarlo Fisichella      Force India      Italian
+    6  Sébastien Buemi           Toro Rosso       Swiss
+    5  Adrian Sutil              Force India      German
+    3  Kamui Kobayashi           Toyota           Japanese
+    2  Sébastien Bourdais        Toro Rosso       French
+    0  Kazuki Nakajima           Williams         Japanese
+    0  Nelson Piquet Jr.         Renault          Brazilian
+    0  Vitantonio Liuzzi         Force India      Italian
+    0  Romain Grosjean           Renault          French
+    0  Jaime Alguersuari         Toro Rosso       Spanish
+    0  Luca Badoer               Ferrari          Italian
+
+  Pts  Construtor       País
+  172  Brawn            British
+153.5  Red Bull         Austrian
+   71  McLaren          British
+   70  Ferrari          Italian
+ 59.5  Toyota           Japanese
+   36  BMW Sauber       German
+ 34.5  Williams         British
+   26  Renault          French
+   13  Force India      Indian
+    8  Toro Rosso       Italian
+
+$ zzf1 1984
+  Pts  Piloto                    Construtor       País
+   72  Niki Lauda                McLaren          Austrian
+ 71.5  Alain Prost               McLaren          French
+   34  Elio de Angelis           Team Lotus       Italian
+ 30.5  Michele Alboreto          Ferrari          Italian
+   29  Nelson Piquet             Brabham          Brazilian
+   27  René Arnoux               Ferrari          French
+   23  Derek Warwick             Renault          British
+ 20.5  Keke Rosberg              Williams         Finnish
+   13  Ayrton Senna              Toleman          Brazilian
+   13  Nigel Mansell             Team Lotus       British
+   11  Patrick Tambay            Renault          French
+    9  Teo Fabi                  Brabham          Italian
+    8  Riccardo Patrese          Alfa Romeo       Italian
+    5  Jacques Laffite           Williams         French
+    5  Thierry Boutsen           Arrows           Belgian
+    3  Eddie Cheever             Alfa Romeo       American
+    3  Stefan Johansson          Tyrrell          Swedish
+    3  Andrea de Cesaris         Ligier           Italian
+    2  Piercarlo Ghinzani        Osella           Italian
+    1  Marc Surer                Arrows           Swiss
+    0  Jo Gartner                Osella           Austrian
+    0  Gerhard Berger            ATS              Austrian
+    0  François Hesnault         Ligier           French
+    0  Corrado Fabi              Brabham          Italian
+    0  Mauro Baldi               Spirit           Italian
+    0  Manfred Winkelhock        ATS              German
+    0  Jonathan Palmer           RAM              British
+    0  Huub Rothengatter         Spirit           Dutch
+    0  Johnny Cecotto            Toleman          Venezuelan
+    0  Philippe Alliot           RAM              French
+
+  Pts  Construtor       País
+143.5  McLaren          British
+ 57.5  Ferrari          Italian
+   47  Team Lotus       British
+   38  Brabham          British
+   34  Renault          French
+ 25.5  Williams         British
+   16  Toleman          British
+   11  Alfa Romeo       Italian
+    6  Arrows           British
+    3  Ligier           French
+    2  Osella           Italian
+    0  ATS              Italian
+    0  Spirit           British
+    0  RAM              British
+    0  Tyrrell          British
+
+$

--- a/zz/zzf1.sh
+++ b/zz/zzf1.sh
@@ -1,0 +1,85 @@
+# ----------------------------------------------------------------------------
+# Mostra a classificação de pilotos e construtores da F1.
+#
+# Opções:
+#   -p: Mostra apenas a classificação por pilotos.
+#   -c: Mostra apenas a classificação por construtores.
+#   ano: Seleciona o ano da classificação.
+#
+# Sem as opções -p e -c mostra ambos.
+# Sem escolher um ano espefífico, exibe o mais atual.
+#
+# Uso: zzf1 [-p|-c] [ano]
+# Ex.: zzf1
+#      zzf1 -p        # Mais recente classificação de pilotos.
+#      zzf1 -c        # Mais recente classificação de construtores.
+#      zzf1 2017      # Classificação de pilotos e construtores em 2017.
+#      zzf1 -p 2015   # Classificação de pilotos em 2015.
+#
+# Autor: Itamar <itamarnet (a) yahoo com br>
+# Desde: 2020-12-26
+# Versão: 1
+# Licença: GPL
+# Requisitos: zzpad zztrim zzxml
+# Tags: internet, corrida, consulta
+# ----------------------------------------------------------------------------
+zzf1 ()
+{
+	zzzz -h f1 "$1" && return
+
+	local pontos piloto nac1 construtor nac2 ano opt fopt
+
+	while test -n "$1"
+	do
+		case $1 in
+			-p) opt='driver'; shift ;;
+			-c) opt='constructor'; shift ;;
+			[0-9][0-9][0-9][0-9]) ano="$1"; shift ;;
+			-*) zztool -e uso f1; return 1 ;;
+			*) break ;;
+		esac
+	done
+
+	ano="${ano:-current}"
+	opt="${opt:-driver constructor}"
+
+	for fopt in $opt
+	do
+		# Pilotos e/ou Construtores
+		zztool source "https://ergast.com/api/f1/${ano}/${fopt}Standings" |
+			zztrim |
+			awk -v optw=$fopt '
+				BEGIN {
+					if (optw=="driver")
+						print "Pts|Piloto||País|Construtor"
+					else
+						print "Pts|Construtor|País"
+				}
+				/(Driver|Constructor)Standing|Name|Nationality/ {
+				if ($0 ~ /points/) {
+					sub(/.*points="/,"")
+					sub(/".*/,"")
+					printf $0; next
+				}
+				if ($0 ~ /(Driver|Constructor)Standing>/) { print ""; next }
+				printf "|" $0
+			}' |
+			zzxml --untag |
+			case $fopt in
+			driver)
+				sed 's/|/ /2' |
+				while IFS='|' read pontos piloto nac1 construtor nac2
+				do
+					echo "$(zzpad -e 5 $pontos)  $(zzpad 25 $piloto) $(zzpad 15 $construtor)  $nac1"
+				done
+			;;
+			constructor)
+				while IFS='|' read pontos construtor nac2
+				do
+					echo "$(zzpad -e 5 $pontos)  $(zzpad 15 $construtor)  $nac2"
+				done
+			;;
+			esac
+			echo
+		done
+}


### PR DESCRIPTION
Ideia baseada na sugestão do @aureliojargas na issue #514 