### PR TITLE
zzdolar: Atualiza testes

### DIFF
--- a/testador/zzdolar.sh
+++ b/testador/zzdolar.sh
@@ -1,4 +1,4 @@
-$ zzdolar | sed 's/[0-9]/9/g;s/[+-]//g;;s/9,99*/NNNNN/g'
+$ zzdolar | sed 's/[0-9]/9/g;s/[+-]//g;;s/9,999/NNNNN/g;s/ 9,99/NNNNN/g;s/  9,9/NNNNN/g'
               Compra   Venda   Var(%)
 Comercial      NNNNN   NNNNN  NNNNN
 Turismo        NNNNN   NNNNN  NNNNN


### PR DESCRIPTION
Em alguns casos, vem os centavos com apenas um dígito.
Agora o filtro sed trata se houver 3, 2 ou 1 dígito após a vírgula.