### PR TITLE
zzcidade: Incluindo Brasília na lista de municípios.

### DIFF
--- a/zz/zzcidade.sh
+++ b/zz/zzcidade.sh
@@ -26,12 +26,15 @@ zzcidade ()
 	# Se o cache está vazio, baixa listagem da Internet
 	if ! test -s "$cache"
 	then
+		# Colocando Brasília manualmente, pois não está na lista do site.
+		echo 'Brasília (DF)' > "$cache"
+
 		# Exemplo:^     * Aracaju (SE)
 		zztool dump "$url" |
 		sed -n '/A\[/,/Ver também\[/p' |
 		sed '/[•*]/!d;s//\
 /g;' | zztrim | zzlimpalixo |
-		LC_ALL=C sort > "$cache"
+		LC_ALL=C sort >> "$cache"
 	fi
 
 	if test -z "$padrao"


### PR DESCRIPTION
Por uma tecnicidade de  natureza jurídica e legal Brasília fica de fora da listagem do site, por isso está sendo colocado a revelia para constar na listagem da função.

O motivo da não inclusão pelo site pode ser visto em: https://pt.wikipedia.org/wiki/Lista_de_munic%C3%ADpios_do_Brasil#cite_note-1