### PR TITLE
zzcinemais: Trocando 'zzuft8' por 'zztool texto_em_iso' devido a falha de conversão do site.

### DIFF
--- a/testador/zzcinemais.sh
+++ b/testador/zzcinemais.sh
@@ -10,18 +10,18 @@ $
 
 # Sem argumentos mostra a lista de cidades/cinemas
 
-$ zzcinemais
+$ zzcinemais | tr -d -c '[0-9A-Za-z -]\n'
 9 - Uberaba  - MG
 11 - Patos de Minas - MG
-21 - Guaratinguetá - SP
-32 - Anápolis - GO
+21 - Guaratinguet - SP
+32 - Anpolis - GO
 34 - Montes Claros - MG
 35 - Shop. Alameda - Juiz de Fora - MG
 36 - Ituiutaba - MG
-37 - Araxá - MG
+37 - Arax - MG
 38 - Lorena - SP
 39 - Jardim Norte - Juiz de Fora - MG
-40 - Drive-in - Uberlândia - MG
+40 - Drive-in - Uberlndia - MG
 $
 
 # Uso normal, informando o número

--- a/zz/zzcinemais.sh
+++ b/zz/zzcinemais.sh
@@ -23,7 +23,7 @@ zzcinemais ()
 
 	cidades=$(
 		zztool source "$url" |
-		zzutf8 |
+		zztool texto_em_iso |
 		sed -n '/cliclabeProg/,/cliclabeProg/p' |
 		zzxml --notag script --tag li |
 		zztrim |

--- a/zz/zzcinemais.sh
+++ b/zz/zzcinemais.sh
@@ -9,8 +9,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-08-25
 # Versão: 11
-# Licença: GPLv2
-# Requisitos: zzecho zzjuntalinhas zztrim zzutf8 zzxml
+# Requisitos: zzzz zztool zzecho zzjuntalinhas zztrim zzutf8 zzxml
 # Tags: internet, cinema
 # ----------------------------------------------------------------------------
 zzcinemais ()


### PR DESCRIPTION
Aparentemente a ` zzutf8 ` não consegue identificar o corretamente a codificação, mesmo usando a ` zzencoding ` para essa tarefa, o que resulta numa saída com caracteres "estranhos".
A substituta ` zztool texto_em_iso ` faz a mesma tarefa, sem uma verificação prévia da codificação original.
A solução funciona, mas não identifico a origem do problema.