### PR TITLE
zzzz --bashrc: Agora com ativação manual (zzon)

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -32,8 +32,8 @@ ZZUTF=1
 #      $ZZTMPDIR   - Diretório para armazenar arquivos temporários
 #      $ZZOFF      - Lista das funções que você não quer carregar
 #
-# Nota: Se você é paranóico com segurança, configure a ZZTMPDIR para
-#       um diretório dentro do seu HOME.
+# Nota: Para ter privacidade em uma máquina compartilhada, configure a
+#       ZZTMPDIR para um diretório dentro do seu HOME.
 #
 ### Configuração fixa neste arquivo (hardcoded)
 #

--- a/funcoeszz
+++ b/funcoeszz
@@ -766,10 +766,13 @@ zzzz ()
 				cat - >> "$bashrc" <<-EOS
 
 				# $instal_msg
-				export ZZOFF=""  # desligue funcoes indesejadas
-				export ZZPATH="$ZZPATH"  # script
-				export ZZDIR="$ZZDIR"    # pasta zz/
-				source "\$ZZPATH"
+				zzon(){
+				    export ZZPATH="$ZZPATH"  # script
+				    export ZZDIR="$ZZDIR"  # pasta zz/
+				    printf "Carregando as funcoeszz... "
+				    source "\$ZZPATH"
+				    echo OK
+				}
 				EOS
 
 				echo 'Feito!'


### PR DESCRIPTION
Agora em vez carregar todas as funções em cada nova shell, há uma função
especial `zzon()` que faz o carregamento das funções, quando o usuário
assim o requisitar.

A vantagem é não carregar as funções desnecessariamente quando você não
irá utilizá-las. Já que temos quase 200 funções, começa a ficar pesado,
principalmente para quem costuma abrir muitos terminais.

Agora que o carregamento é manual e explícito, está ok carregar sempre
todas as funções incondicionalmente, por isso a menção à `ZZOFF` foi
removida. Ela ainda funciona, é claro, então quem quiser basta usar.

Exemplo de como fica:

```bash
# Instalacao das Funcoes ZZ (www.funcoeszz.net)
zzon(){
    export ZZPATH="/home/aurelio/k/a/funcoeszz/funcoeszz"  # script
    export ZZDIR="/home/aurelio/k/a/funcoeszz/zz"  # pasta zz/
    printf "Carregando as funcoeszz... "
    source "$ZZPATH"
    echo "OK"
}
```

Issue: #568 