### PR TITLE
Licença: deixa claro que é GPL-2.0-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Funções ZZ é uma coletânea com mais de 180 miniaplicativos de utilidades div
 - GitHub: https://github.com/funcoeszz/funcoeszz
 - Wiki: https://github.com/funcoeszz/funcoeszz/wiki
 - Twitter: https://twitter.com/Funcoes_ZZ
+- Licença: [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html)
 
 
 ## Lista de colaboradores

--- a/funcoeszz
+++ b/funcoeszz
@@ -8,7 +8,7 @@
 #              Thobias Salazar Trevisan <thobias (a) thobias org>
 # DESCRIÇÃO  : Funções de uso geral para o shell Bash, que buscam
 #              informações em arquivos locais e fontes na Internet
-# LICENÇA    : GPLv2
+# LICENÇA    : GPL-2.0-only
 # CHANGELOG  : http://www.funcoeszz.net/changelog.html
 #
 ZZVERSAO=dev


### PR DESCRIPTION
O termo "GPLv2" pode gerar dúvida se é apenas a versão 2 mesmo, ou
versão 2 e mais recentes. Agora não há margem para dúvida.

Essa informação também foi colocada no README, para maior visibilidade.