### PR TITLE
Retirando o campo Licença de todas as funções.

### DIFF
--- a/off/zzanatel.sh
+++ b/off/zzanatel.sh
@@ -7,7 +7,6 @@
 # Autor: Rafael Machado Casali <rmcasali (a) gmail com>
 # Desde: 2005-04-14
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-28 Parou de funcionar (issue #48)
 zzanatel ()

--- a/off/zzbolsas.sh
+++ b/off/zzbolsas.sh
@@ -50,7 +50,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2009-10-04
 # Versão: 25
-# Licença: GPL
 # Requisitos: zzcolunar zzdatafmt zzjuntalinhas zzlimpalixo zzmaiusculas zzsqueeze zztrim zzunescape zzxml
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-09-28 Qualidade das informações é duvidosa e imprecisa.

--- a/off/zzbovespa.sh
+++ b/off/zzbovespa.sh
@@ -11,7 +11,6 @@
 # Autor: Denis Dias de Lima <denis (a) concatenum com>
 # Desde: 2004-05-18
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2008-03-01 Agora os sites usam AJAX :(
 zzbovespa ()

--- a/off/zzcasadosartistas.sh
+++ b/off/zzcasadosartistas.sh
@@ -7,7 +7,6 @@
 # Autor: Aurélio Marinho Jargas, www.aurelio.net
 # Desde: 2002-02-18
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2002-10-30 O programa acabou.
 zzcasadosartistas ()

--- a/off/zzcbn.sh
+++ b/off/zzcbn.sh
@@ -10,7 +10,6 @@
 # Autor: Rafael Machado Casali <rmcasali (a) gmail com>
 # Desde: 2009-04-16
 # Versão: 8
-# Licença: GPL
 # Requisitos: zzecho zzplay zzcapitalize zzdatafmt zzxml zzutf8
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2018-01-27 Site usando técnicas AJAX.

--- a/off/zzcinemark.sh
+++ b/off/zzcinemark.sh
@@ -14,7 +14,6 @@
 # Autor: Thiago Moura Witt <thiago.witt (a) gmail.com> <@thiagowitt>
 # Desde: 2011-07-05
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzdatafmt zzxml zzunescape zztrim
 # Tags: cinema
 # ----------------------------------------------------------------------------

--- a/off/zzcinepolis.sh
+++ b/off/zzcinepolis.sh
@@ -9,7 +9,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-02-22
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzdatafmt zzjuntalinhas zzlimpalixo zzminusculas zzpad zzsemacento zzsqueeze zztrim zzunescape zzutf8 zzxml
 # Tags: cinema
 # ----------------------------------------------------------------------------

--- a/off/zzconjuga.sh
+++ b/off/zzconjuga.sh
@@ -7,7 +7,6 @@
 # Autor: Leslie Harlley Watter <leslie (a) watter org>
 # Desde: 2003-08-05
 # Versão: 2
-# Licença: GPL
 # Nota: Colaboração de José Inácio Coelho <jinacio (a) yahoo com>
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 "This domain is for sale." :(

--- a/off/zzcopa.sh
+++ b/off/zzcopa.sh
@@ -40,7 +40,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-12-07
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2014-06-30 Não funciona mais, site usando AJAX :/
 zzcopa ()

--- a/off/zzcorrida.sh
+++ b/off/zzcorrida.sh
@@ -16,15 +16,12 @@
 #   Truck Series (Nascar): nascar2 ou truck_series
 #   Nationwide Series (Nascar): nascar3 ou nationwide
 #
-# Uso: zzcorrida <f1|indy|gp2|truck|truck_sul|stock|rali>
-# Uso: zzcorrida <moto|moto_gp|moto2|moto3>
-# Uso: zzcorrida <nascar|sprint_cup|nascar2|truck_series|nascar3|nationwide>
+# Uso: zzcorrida <código da corrida>
 # Ex.: zzcorrida truck
 #
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2011-11-02
 # Versão: 7
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2014-04-20 O site encerrou e sem um substituto equivalente.
 zzcorrida ()

--- a/off/zzdata2.sh
+++ b/off/zzdata2.sh
@@ -20,7 +20,6 @@
 # Autor: Aurélio Marinho Jargas, www.aurelio.net, modificada por Lauro de Sá
 # Desde: 2010-05-26
 # Versão: 20091010
-# Licença: GPLv2
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2011-05-19 Funcionalidades implementadas na zzdata original.
 zzdata2 ()

--- a/off/zzdatabarras.sh
+++ b/off/zzdatabarras.sh
@@ -9,7 +9,6 @@
 # Autor: Lauro Cavalcanti de Sa <lauro (a) ecdesa com>
 # Desde: 2010-01-28
 # Versão: 20100128
-# Licença: GPLv2
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2011-05-24 Funcionalidades implementadas na zzdatafmt.
 zzdatabarras ()

--- a/off/zzdebgen.sh
+++ b/off/zzdebgen.sh
@@ -31,7 +31,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2012-04-08
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzecho
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-28 Parou de funcionar (issue #50)

--- a/off/zzdefine.sh
+++ b/off/zzdefine.sh
@@ -9,7 +9,6 @@
 # Autor: Fernando Aires <fernandoaires (a) gmail com>
 # Desde: 2005-05-23
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-28 Parou de funcionar (issue #53)
 zzdefine ()

--- a/off/zzdefinr.sh
+++ b/off/zzdefinr.sh
@@ -8,7 +8,6 @@
 # Autor: Felipe Arruda <felipemiguel (a) gmail com>
 # Desde: 2008-08-15
 # Versão: 1
-# Licença: GPL
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2020-12-22 Site foi descontinuado (veja issue #599)

--- a/off/zzdelicious.sh
+++ b/off/zzdelicious.sh
@@ -8,7 +8,6 @@
 # Autor: Felipe Nascimento Silva Pena <felipensp (a) gmail com>
 # Desde: 2007-12-04
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-28 Parou de funcionar (issue #60)
 zzdelicious ()

--- a/off/zzdetranes.sh
+++ b/off/zzdetranes.sh
@@ -6,7 +6,6 @@
 # Autor: Kl0nEz <kl0nez (a) wifi org br>
 # Desde: 2005-02-23
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 O endereço está retornando um IFRAME.
 zzdetranes ()

--- a/off/zzdetranpr.sh
+++ b/off/zzdetranpr.sh
@@ -7,7 +7,6 @@
 # Autor: Aurélio Marinho Jargas, www.aurelio.net
 # Desde: 2001-02-14
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2008-03-01 Agora a consulta é travada com CAPTCHA
 zzdetranpr ()

--- a/off/zzdetransp.sh
+++ b/off/zzdetransp.sh
@@ -7,7 +7,6 @@
 # Autor: Elton Simões Baptista <elton (a) inso com br>
 # Desde: 2001-12-06
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-24 URL não encontrada (404)
 zzdetransp ()

--- a/off/zzdicbabelfish.sh
+++ b/off/zzdicbabelfish.sh
@@ -18,7 +18,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-22 O Babelfish, virou Yahoo, depois Bing. zzdicbing?
 zzdicbabelfish ()

--- a/off/zzdicgoogle.sh
+++ b/off/zzdicgoogle.sh
@@ -15,7 +15,6 @@
 # Autor: Rodrigo Bernardo Pimentel <rbp (a) isnomore net>
 # Desde: 2003-12-20
 # Versão: 3
-# Licença: GPL
 # Nota: Colaboração de Humberto Sartini <betinho_pg (a) yahoo com br>
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 Filtro quebrado. Substituída pela zztradutor.

--- a/off/zzdictodos.sh
+++ b/off/zzdictodos.sh
@@ -6,7 +6,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzdicbabelfish zzdicbabylon zzdicjargon zzdicportugues
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-22 Hoje não faz mais sentido essa função…

--- a/off/zzdilbert.sh
+++ b/off/zzdilbert.sh
@@ -8,7 +8,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-05-19
 # Versão: 1
-# Licença: GPL
 # Requisitos: zztrim zzunescape zzxml
 # Tags: internet, distração
 # ----------------------------------------------------------------------------

--- a/off/zzenviaemail.sh
+++ b/off/zzenviaemail.sh
@@ -17,7 +17,6 @@
 # Autor: Lauro Cavalcanti de Sa <lauro (a) ecdesa com>
 # Desde: 2009-09-17
 # Versão: 2
-# Licença: GPLv2
 # Nota: requer ssmtp
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-05-21 comando ssmtp não funciona (veja issue #298)

--- a/off/zzeuro.sh
+++ b/off/zzeuro.sh
@@ -7,7 +7,6 @@
 # Autor: Kyller Costa Gorgônio <kyllercg (a) gmail com>
 # Desde: 2006-01-10
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-28 Parou de funcionar (issue #64)
 zzeuro ()

--- a/off/zzfilme.sh
+++ b/off/zzfilme.sh
@@ -6,7 +6,6 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2008-01-03
 # Versão: 3
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 Cada dia da semana agora é um link para uma nova URL
 zzfilme ()

--- a/off/zzfreshmeat.sh
+++ b/off/zzfreshmeat.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-09-20
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2014-09-01 Site em modo estático. Ver Issue #143
 zzfreshmeat ()

--- a/off/zzgoogle.sh
+++ b/off/zzgoogle.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-04-03
 # Versão: 3
-# Licença: GPL
 # Requisitos: zztrim
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-11-17 Google bloqueia robôs (issue #390)

--- a/off/zzhastebin.sh
+++ b/off/zzhastebin.sh
@@ -8,7 +8,6 @@
 # Autor: Jones Dias <diasjones07 (a) gmail.com>
 # Desde: 2015-02-12
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2018-01-27 curl falha, precisa do haste (ruby e xcode)
 zzhastebin ()

--- a/off/zzirpf.sh
+++ b/off/zzirpf.sh
@@ -8,7 +8,6 @@
 # Autor: Rodrigo Stulzer Lopes, www.stulzer.net
 # Desde: 2001-08-09
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2008-03-01 Agora a consulta é travada com CAPTCHA
 zzirpf ()

--- a/off/zzjuros.sh
+++ b/off/zzjuros.sh
@@ -11,7 +11,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-05-06
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzxml zzunescape
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-08-28 Site usa webservice com AJAX :(

--- a/off/zzkill.sh
+++ b/off/zzkill.sh
@@ -10,7 +10,6 @@
 # Autor: Ademar de Souza Reis Jr.
 # Desde: 2000-05-15
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-11-16 O comando pkill a substitui (issue #362)
 zzkill ()

--- a/off/zzletrademusica.sh
+++ b/off/zzletrademusica.sh
@@ -12,7 +12,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org - revisado por Itamar
 # Desde: 2002-04-23
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzsemacento
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-26 URL ainda existe, mas não retorna nada. [issue #31]

--- a/off/zzmoeda.sh
+++ b/off/zzmoeda.sh
@@ -13,7 +13,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-03-29
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2015-02-24 Site foi descontinuado (veja issue #160)
 zzmoeda ()

--- a/off/zznarrativa.sh
+++ b/off/zznarrativa.sh
@@ -8,7 +8,6 @@
 # Autor: Kl0nEz <kl0nez (a) wifi org br>
 # Desde: 2011-08-23
 # Versão: 4
-# Licença: GPLv2
 # Requisitos: zzplay
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-02-15 Apenas para usuário autenticado ( Veja issue #231 )

--- a/off/zznextel.sh
+++ b/off/zznextel.sh
@@ -8,7 +8,6 @@
 # Autor: Aurélio Marinho Jargas, www.aurelio.net
 # Desde: 2002-03-15
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2008-03-01 Agora a consulta é travada com CAPTCHA
 zznextel ()

--- a/off/zznoticias.sh
+++ b/off/zznoticias.sh
@@ -9,7 +9,6 @@
 # Autor: Frederico Freire Boaventura <anonymous (a) galahad com br>
 # Desde: 2005-04-02
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 URL parece ok, mas o filtro está quebrado.
 zznoticias ()

--- a/off/zzoperadora.sh
+++ b/off/zzoperadora.sh
@@ -8,7 +8,6 @@
 # Autor: Mauricio Calligaris <mauriciocalligaris@gmail.com>
 # Desde: 2013-06-19
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzutf8
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-09-03 Site usam AJAX, impossível consultar :(

--- a/off/zzpiada.sh
+++ b/off/zzpiada.sh
@@ -7,7 +7,6 @@
 # Autor: Alexandre Brodt Fernandes, www.xalexandre.com.br
 # Desde: 2008-12-29
 # Versão: 3
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-04-14 Site inativo
 zzpiada ()

--- a/off/zzppt.sh
+++ b/off/zzppt.sh
@@ -7,7 +7,6 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2007-11-30
 # Versão: 1.1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 URL funciona, mas não traz datas ou agenda.
 zzppt ()

--- a/off/zzquebramd5.sh
+++ b/off/zzquebramd5.sh
@@ -6,7 +6,6 @@
 # Autor: Fernando Mercês <fernando (a) mentebinaria.com.br>
 # Desde: 2012-02-24
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-27 Aparentemente não está funcionando (issue #29)
 zzquebramd5 ()

--- a/off/zzrandbackground.sh
+++ b/off/zzrandbackground.sh
@@ -12,7 +12,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-12-12
 # Versão: 1
-# Licença: GPLv2
 # Requisitos: zzshuffle
 # Nota: requer gconftool
 # ----------------------------------------------------------------------------

--- a/off/zzranking.sh
+++ b/off/zzranking.sh
@@ -7,7 +7,6 @@
 # Autor: Cesar Gimenes <crgimenes (a) terra com br>
 # Desde: 2005-11-03
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 URL não encontrada (404)
 zzranking ()

--- a/off/zzrelansi.sh
+++ b/off/zzrelansi.sh
@@ -6,7 +6,6 @@
 # Autor: Arkanon <arkanon (a) lsd org br>
 # Desde: 2009-09-17
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2016-11-16 Fora do escopo do projeto (issue #364)
 zzrelansi ()

--- a/off/zzselic.sh
+++ b/off/zzselic.sh
@@ -18,7 +18,6 @@
 # Autor: Guilherme Magalhães Gall <gmgall (a) gmail com>
 # Desde: 2015-06-07
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzdata zzdiadasemana zzdos2unix zzferiado zzurlencode zzutf8 zzpad
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2018-01-06 Página do Banco Central usando AJAX.

--- a/off/zzseq2.sh
+++ b/off/zzseq2.sh
@@ -8,7 +8,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2009-10-04
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-21 Funcionalidades implementadas na zzseq original.
 zzseq2 ()

--- a/off/zztelecine.sh
+++ b/off/zztelecine.sh
@@ -7,7 +7,6 @@
 # Autor: Frederico Freire Boaventura <anonymous (a) galahad com br>
 # Desde: 2005-04-02
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 Filtro quebrado. A saída aparece bagunçada.
 zztelecine ()

--- a/off/zztradutor.sh
+++ b/off/zztradutor.sh
@@ -26,7 +26,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-09-02
 # Versão: 13
-# Licença: GPLv2
 # Requisitos: zzxml zzplay zzunescape zzutf8
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/off/zztweets.sh
+++ b/off/zztweets.sh
@@ -9,7 +9,6 @@
 # Autor: Eri Ramos Bastos <bastos.eri (a) gmail.com>
 # Desde: 2009-07-30
 # Versão: 10
-# Licença: GPL
 # Requisitos: zzsqueeze zztrim
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/off/zztwitter.sh
+++ b/off/zztwitter.sh
@@ -14,7 +14,6 @@
 # Autor: Edson Ramiro <erlfilho (a) gmail com>
 # Desde: 2009-09-24
 # Versão: 2
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2015-04-05 Parou de funcionar (veja issue #205)
 

--- a/off/zzve.sh
+++ b/off/zzve.sh
@@ -19,7 +19,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-07-28
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzuniq
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2018-01-06 Informação acessível apenas a assinantes no site.

--- a/off/zzwhoisbr.sh
+++ b/off/zzwhoisbr.sh
@@ -8,7 +8,6 @@
 # Autor: Marcelo Subtil Marçal
 # Desde: 2001-12-14
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2013-02-27 Hoje o comando whois pega domínios .br (issue #37)
 zzwhoisbr ()

--- a/off/zzystock.sh
+++ b/off/zzystock.sh
@@ -7,7 +7,6 @@
 # Autor: Eustáquio Rangel "TaQ" <eustaquiorangel (a) yahoo com>
 # Desde: 2004-11-05
 # Versão: 1
-# Licença: GPL
 # ----------------------------------------------------------------------------
 # DESATIVADA: 2010-12-22 URL e dados ok, mas o filtro precisa ser refeito.
 zzystock ()

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -34,11 +34,6 @@ case "$1" in
 		sed "s/:# Versão: /$tab/" |
 		sed "s/\(.*\)$tab\(.*\)/\2$tab\1/"
 	;;
-	licen[cç]a | l)
-		grep '# Licença:' zz/*.sh off/*.sh |
-		sed "s/:# Licença: /$tab/" |
-		sed "s/\(.*\)$tab\(.*\)/\2$tab\1/"
-	;;
 	requisitos | r)
 		IFS=':'
 		grep '# Requisitos:' zz/*.sh off/*.sh |

--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -45,9 +45,8 @@ for f in zz/*.sh off/*.sh; do grep "^$(basename $f .sh) " $f >/dev/null || echo 
 
 eco ----------------------------------------------------------------
 eco "* Funções com o cabeçalho mal formatado"
-for f in zz/*.sh off/*.sh
+for f in zz/*.sh
 do
-	echo "$f" | grep 'zzcorrida' > /dev/null && continue
 	wrong=$(sed -n '
 
 		# Script sed que vai lendo o cabeçalho linha a linha e
@@ -74,7 +73,6 @@ do
 			/^# Autor: /      { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Desde: /      { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Versão: /     { s/^/Deveria vir depois dos exemplos -- /p; q; }
-			# /^# Licença: /    { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Requisitos: / { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Tags: /       { s/^/Deveria vir depois dos exemplos -- /p; q; }
 
@@ -107,8 +105,6 @@ do
 			/^# Desde: /! { s/^/Esperava Desde: …, veio /p; q; }
 			n
 			/^# Versão: / ! { s/^/Esperava Versão: …, veio /p; q; }
-			n
-			#/^# Licença: /! { s/^/Esperava Licença: …, veio /p; q; }
 			n
 
 			# Mais campos opcionais no final

--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -74,7 +74,7 @@ do
 			/^# Autor: /      { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Desde: /      { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Versão: /     { s/^/Deveria vir depois dos exemplos -- /p; q; }
-			/^# Licença: /    { s/^/Deveria vir depois dos exemplos -- /p; q; }
+			# /^# Licença: /    { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Requisitos: / { s/^/Deveria vir depois dos exemplos -- /p; q; }
 			/^# Tags: /       { s/^/Deveria vir depois dos exemplos -- /p; q; }
 
@@ -108,7 +108,7 @@ do
 			n
 			/^# Versão: / ! { s/^/Esperava Versão: …, veio /p; q; }
 			n
-			/^# Licença: /! { s/^/Esperava Licença: …, veio /p; q; }
+			#/^# Licença: /! { s/^/Esperava Licença: …, veio /p; q; }
 			n
 
 			# Mais campos opcionais no final
@@ -174,11 +174,10 @@ do
 done
 
 eco ----------------------------------------------------------------
-eco "* Funções com conteúdo inválido no campo Licença:"
-for f in zz/*.sh off/*.sh
+eco "* Funções com o campo inválido Licença:"
+for f in zz/*.sh
 do
-	wrong=$(grep '^# Licença:' $f | egrep -v '^# Licença: (GPL(v2)?|MIT)$')
-	# Se alguém quiser usar outra licença, basta adicionar aqui ^
+	wrong=$(grep '^# Licença:' $f)
 	test -n "$wrong" && echo "$f: $wrong"
 done
 

--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -45,7 +45,7 @@ for f in zz/*.sh off/*.sh; do grep "^$(basename $f .sh) " $f >/dev/null || echo 
 
 eco ----------------------------------------------------------------
 eco "* Funções com o cabeçalho mal formatado"
-for f in zz/*.sh
+for f in zz/*.sh off/*.sh
 do
 	wrong=$(sed -n '
 
@@ -222,7 +222,7 @@ grep -H '^#.*	' zz/*.sh off/*.sh
 #
 # eco ----------------------------------------------------------------
 # eco "* Funções com campo desconhecido"
-# campos='Obs\.|Opções|Uso|Ex\.|Autor|Desde|Versão|Licença|Requisitos|Nota'
+# campos='Obs\.|Opções|Uso|Ex\.|Autor|Desde|Versão|Requisitos|Nota'
 # for f in zz/*.sh off/*.sh
 # do
 # 	wrong=$(

--- a/zz/zzaleatorio.sh
+++ b/zz/zzaleatorio.sh
@@ -12,7 +12,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-13
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzvira
 # Tags: número, RANDOM, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzalfabeto.sh
+++ b/zz/zzalfabeto.sh
@@ -28,7 +28,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-07-23
 # Versão: 6
-# Licença: GPL
 # Requisitos: zzmaiusculas zztrim
 # Tags: texto, tabela
 # ----------------------------------------------------------------------------

--- a/zz/zzalinhar.sh
+++ b/zz/zzalinhar.sh
@@ -19,7 +19,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-05-23
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzpad zztrim zzwc
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzansi2html.sh
+++ b/zz/zzansi2html.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-09-02
 # Versão: 3
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzansi2html ()

--- a/zz/zzarrumacidade.sh
+++ b/zz/zzarrumacidade.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzcapitalize
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzarrumanome.sh
+++ b/zz/zzarrumanome.sh
@@ -14,7 +14,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-07-23
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzminusculas
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzascii.sh
+++ b/zz/zzascii.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-12-06
 # Versão: 6
-# Licença: GPL
 # Requisitos: zzseq zzcolunar
 # Tags: texto, tabela
 # ----------------------------------------------------------------------------

--- a/zz/zzbeep.sh
+++ b/zz/zzbeep.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-04-24
 # Versão: 1
-# Licença: GPL
 # Tags: utilitário, emulação
 # ----------------------------------------------------------------------------
 zzbeep ()

--- a/zz/zzbicho.sh
+++ b/zz/zzbicho.sh
@@ -12,7 +12,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2012-08-27
 # Versão: 4
-# Licença: GPL
 # Requisitos: zztrim
 # Tags: jogo, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzbissexto.sh
+++ b/zz/zzbissexto.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-21
 # Versão: 1
-# Licença: GPL
 # Requisitos: zztestar
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzblist.sh
+++ b/zz/zzblist.sh
@@ -6,7 +6,6 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2008-10-16
 # Versão: 5
-# Licença: GPL
 # Requisitos: zztestar
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzbraille.sh
+++ b/zz/zzbraille.sh
@@ -30,7 +30,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-05-26
 # Versão: 6
-# Licença: GPL
 # Requisitos: zzminusculas zzmaiusculas zzcapitalize zzseq zztestar
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzbrasileirao.sh
+++ b/zz/zzbrasileirao.sh
@@ -21,7 +21,6 @@
 # Autor: Alexandre Brodt Fernandes, www.xalexandre.com.br
 # Desde: 2011-05-28
 # Versão: 27
-# Licença: GPL
 # Requisitos: zzecho zzjuntalinhas zzpad zzxml
 # Tags: internet, futebol, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzbyte.sh
+++ b/zz/zzbyte.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-03-01
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzmaiusculas
 # Tags: número, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzcalcula.sh
+++ b/zz/zzcalcula.sh
@@ -13,7 +13,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-04
 # Versão: 3
-# Licença: GPL
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------
 zzcalcula ()

--- a/zz/zzcalculaip.sh
+++ b/zz/zzcalculaip.sh
@@ -10,7 +10,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2005-09-01
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzconverte zztestar
 # Tags: ip, cálculo
 # ----------------------------------------------------------------------------

--- a/zz/zzcapitalize.sh
+++ b/zz/zzcapitalize.sh
@@ -17,7 +17,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzminusculas
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzcaracoroa.sh
+++ b/zz/zzcaracoroa.sh
@@ -6,7 +6,6 @@
 # Autor: Angelito M. Goulart, www.angelitomg.com
 # Desde: 2012-12-06
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzaleatorio
 # Tags: RANDOM, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzcarnaval.sh
+++ b/zz/zzcarnaval.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-23
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzdata zzpascoa
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzcep.sh
+++ b/zz/zzcep.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-11-08
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzsemacento zzminusculas zzxml zzjuntalinhas zzcolunar zztrim zzpad
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzchavepgp.sh
+++ b/zz/zzchavepgp.sh
@@ -8,7 +8,6 @@
 # Autor: Rodrigo Missiaggia
 # Desde: 2001-10-01
 # Versão: 1
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzchavepgp ()

--- a/zz/zzchecamd5.sh
+++ b/zz/zzchecamd5.sh
@@ -7,7 +7,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-10-31
 # Versão: 3
-# Licença: GPLv2
 # Requisitos: zzmd5
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzcidade.sh
+++ b/zz/zzcidade.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzlinha zztrim zzlimpalixo
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzcinclude.sh
+++ b/zz/zzcinclude.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-12-15
 # Versão: 1
-# Licença: GPL
 # Tags: arquivo, consulta
 # Nota: requer cpp
 # ----------------------------------------------------------------------------

--- a/zz/zzcinemais.sh
+++ b/zz/zzcinemais.sh
@@ -9,7 +9,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-08-25
 # Versão: 11
-# Licença: GPLv2
 # Requisitos: zzecho zzjuntalinhas zztrim zzutf8 zzxml
 # Tags: internet, cinema
 # ----------------------------------------------------------------------------

--- a/zz/zzcineuci.sh
+++ b/zz/zzcineuci.sh
@@ -8,7 +8,6 @@
 # Autor: Rodrigo Pereira da Cunha <rodrigopc (a) gmail.com>
 # Desde: 2009-05-04
 # Versão: 10
-# Licença: GPL
 # Requisitos: zzunescape zztrim zzcolunar
 # Tags: internet, cinema
 # ----------------------------------------------------------------------------

--- a/zz/zzclassnum.sh
+++ b/zz/zzclassnum.sh
@@ -7,7 +7,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-05-12
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzdivisores zzmat zztestar zzvira
 # Tags: número
 # ----------------------------------------------------------------------------

--- a/zz/zzcnpj.sh
+++ b/zz/zzcnpj.sh
@@ -13,7 +13,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-12-23
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzaleatorio
 # Tags: internet, cálculo, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzcodchar.sh
+++ b/zz/zzcodchar.sh
@@ -18,7 +18,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-12-07
 # Versão: 3
-# Licença: GPL
 # Requisitos: zztrim zzpad
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzcodq.sh
+++ b/zz/zzcodq.sh
@@ -12,7 +12,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-07
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzcolunar zzcut zzjuntalinhas zzmaiusculas zzwc zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzcoin.sh
+++ b/zz/zzcoin.sh
@@ -12,7 +12,6 @@
 # Autor: Tárcio Zemel <tarciozemel (a) gmail com>
 # Desde: 2014-03-24
 # Versão: 7
-# Licença: GPL
 # Requisitos: zzmaiusculas zznumero zzpad zzsemacento zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzcolunar.sh
+++ b/zz/zzcolunar.sh
@@ -38,7 +38,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-04-24
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzalinhar zztrim
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzconfere.sh
+++ b/zz/zzconfere.sh
@@ -31,7 +31,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-11-25
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzhsort zzloteria
 # Tags: internet, jogo, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzconjugar.sh
+++ b/zz/zzconjugar.sh
@@ -15,7 +15,6 @@
 # Autor: Leslie Harlley Watter <leslie (a) watter org>
 # Desde: 2003-08-05
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzalinhar zzcolunar zzjuntalinhas zzlblank zzminusculas zzsemacento zzsqueeze zztrim zzutf8 zzxml
 # Tags: internet, consulta
 # Nota: Colaboração de José Inácio Coelho <jinacio (a) yahoo com>

--- a/zz/zzconstantes.sh
+++ b/zz/zzconstantes.sh
@@ -18,7 +18,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-04
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzcut zzjuntalinhas zzpad zzsqueeze zzunescape zzutf8 zzwc zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzcontapalavra.sh
+++ b/zz/zzcontapalavra.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-10-02
 # Versão: 1
-# Licença: GPL
 # Tags: texto, contagem
 # ----------------------------------------------------------------------------
 zzcontapalavra ()

--- a/zz/zzcontapalavras.sh
+++ b/zz/zzcontapalavras.sh
@@ -13,7 +13,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-07
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzminusculas
 # Tags: texto, contagem
 # ----------------------------------------------------------------------------

--- a/zz/zzconverte.sh
+++ b/zz/zzconverte.sh
@@ -53,7 +53,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2003-10-02
 # Versão: 6
-# Licença: GPL
 # Requisitos: zznumero zztestar
 # Tags: número, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzcores.sh
+++ b/zz/zzcores.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-12-11
 # Versão: 1
-# Licença: GPL
 # Tags: cores, tabela
 # ----------------------------------------------------------------------------
 zzcores ()

--- a/zz/zzcorpuschristi.sh
+++ b/zz/zzcorpuschristi.sh
@@ -9,7 +9,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-11-21
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzdata zzpascoa
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzcotacao.sh
+++ b/zz/zzcotacao.sh
@@ -7,7 +7,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-19
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzjuntalinhas zznumero zzpad zzsqueeze zztrim zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzcpf.sh
+++ b/zz/zzcpf.sh
@@ -13,7 +13,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-12-23
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzaleatorio zzcut
 # Tags: cálculo, consulta, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzcut.sh
+++ b/zz/zzcut.sh
@@ -53,7 +53,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-02-09
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzunescape
 # Tags: cut, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzdado.sh
+++ b/zz/zzdado.sh
@@ -11,7 +11,6 @@
 # Autor: Angelito M. Goulart, www.angelitomg.com
 # Desde: 2012-12-05
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzaleatorio
 # Tags: RANDOM, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzdata.sh
+++ b/zz/zzdata.sh
@@ -25,7 +25,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-02-07
 # Versão: 5
-# Licença: GPL
 # Requisitos: zztestar
 # Tags: data, cálculo
 # ----------------------------------------------------------------------------

--- a/zz/zzdataestelar.sh
+++ b/zz/zzdataestelar.sh
@@ -20,7 +20,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-10-28
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzdata zzdatafmt zznumero zzhora
 # Tags: data, cálculo
 # ----------------------------------------------------------------------------

--- a/zz/zzdatafmt.sh
+++ b/zz/zzdatafmt.sh
@@ -47,7 +47,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-24
 # Versão: 11
-# Licença: GPL
 # Requisitos: zzdata zzminusculas zznumero zzdiadasemana
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzddd.sh
+++ b/zz/zzddd.sh
@@ -14,7 +14,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-06
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzjuntalinhas zzminusculas zzpad zzsemacento zztrim zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzdiadasemana.sh
+++ b/zz/zzdiadasemana.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-24
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzdata
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzdiasuteis.sh
+++ b/zz/zzdiasuteis.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-20
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzdata zzdiadasemana zzdatafmt zzcapitalize
 # Tags: data, cálculo
 # ----------------------------------------------------------------------------

--- a/zz/zzdicantonimos.sh
+++ b/zz/zzdicantonimos.sh
@@ -7,7 +7,6 @@
 # Autor: gabriell nascimento <gabriellhrn (a) gmail com>
 # Desde: 2013-04-15
 # Versão: 3
-# Licença: GPL
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicantonimos ()

--- a/zz/zzdicasl.sh
+++ b/zz/zzdicasl.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-08-08
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzutf8
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzdicbabylon.sh
+++ b/zz/zzdicbabylon.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
-# Licença: GPL
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicbabylon ()

--- a/zz/zzdicesperanto.sh
+++ b/zz/zzdicesperanto.sh
@@ -12,7 +12,6 @@
 # Autor: Fernando Aires <fernandoaires (a) gmail com>
 # Desde: 2005-05-20
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzurlencode
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------

--- a/zz/zzdicjargon.sh
+++ b/zz/zzdicjargon.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
-# Licença: GPL
 # Requisitos: zztrim zzdividirtexto
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------

--- a/zz/zzdicportugues.sh
+++ b/zz/zzdicportugues.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-02-26
 # Versão: 11
-# Licença: GPL
 # Requisitos: zzsemacento zzminusculas zztrim
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------

--- a/zz/zzdicsinonimos.sh
+++ b/zz/zzdicsinonimos.sh
@@ -7,7 +7,6 @@
 # Autor: gabriell nascimento <gabriellhrn (a) gmail com>
 # Desde: 2013-04-15
 # Versão: 3
-# Licença: GPL
 # Requisitos: zztrim
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------

--- a/zz/zzdiffpalavra.sh
+++ b/zz/zzdiffpalavra.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-07-23
 # Versão: 3
-# Licença: GPL
 # Tags: diff, emulação
 # ----------------------------------------------------------------------------
 zzdiffpalavra ()

--- a/zz/zzdistro.sh
+++ b/zz/zzdistro.sh
@@ -14,7 +14,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-06-15
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzcolunar
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzdividirtexto.sh
+++ b/zz/zzdividirtexto.sh
@@ -10,7 +10,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-04-12
 # Versão: 1
-# Licença: GPL
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzdividirtexto ()

--- a/zz/zzdivisores.sh
+++ b/zz/zzdivisores.sh
@@ -7,7 +7,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-25
 # Versão: 6
-# Licença: GPL
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------
 zzdivisores ()

--- a/zz/zzdolar.sh
+++ b/zz/zzdolar.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 9
-# Licença: GPL
 # Requisitos: zzcotacao
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzdominiopais.sh
+++ b/zz/zzdominiopais.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-15
 # Versão: 3
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzdominiopais ()

--- a/zz/zzdos2unix.sh
+++ b/zz/zzdos2unix.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
-# Licença: GPL
 # Tags: arquivo, conversão
 # ----------------------------------------------------------------------------
 zzdos2unix ()

--- a/zz/zzecho.sh
+++ b/zz/zzecho.sh
@@ -16,7 +16,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-09-02
 # Versão: 3
-# Licença: GPL
 # Tags: echo, emulação
 # ----------------------------------------------------------------------------
 zzecho ()

--- a/zz/zzencoding.sh
+++ b/zz/zzencoding.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2015-03-21
 # Versão: 1
-# Licença: GPL
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzencoding ()

--- a/zz/zzenglish.sh
+++ b/zz/zzenglish.sh
@@ -7,7 +7,6 @@
 # Autor: Luciano ES
 # Desde: 2008-09-07
 # Versão: 7
-# Licença: GPL
 # Requisitos: zztrim zzutf8 zzsqueeze
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------

--- a/zz/zzestado.sh
+++ b/zz/zzestado.sh
@@ -27,7 +27,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzpad
 # Tags: utilitário
 # ----------------------------------------------------------------------------

--- a/zz/zzexcuse.sh
+++ b/zz/zzexcuse.sh
@@ -7,7 +7,6 @@
 # Autor: Italo Gonçales, @goncalesi, <italo.goncales (a) gmail com>
 # Desde: 2015-09-26
 # Versão: 2
-# Licença: GPL
 # Requisitos: zztrim
 # Tags: internet, diversão
 # ----------------------------------------------------------------------------

--- a/zz/zzextensao.sh
+++ b/zz/zzextensao.sh
@@ -8,7 +8,6 @@
 # Autor: Lauro Cavalcanti de Sa <lauro (a) ecdesa com>
 # Desde: 2009-09-21
 # Versão: 3
-# Licença: GPLv2
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzextensao ()

--- a/zz/zzf1.sh
+++ b/zz/zzf1.sh
@@ -19,7 +19,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2020-12-26
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzpad zztrim zzxml
 # Tags: internet, corrida, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -14,7 +14,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-14
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzjuntalinhas zzdivisores
 # Tags: número, cálculo
 # Nota: opcional factor

--- a/zz/zzfeed.sh
+++ b/zz/zzfeed.sh
@@ -19,7 +19,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-03
 # Versão: 11
-# Licença: GPL
 # Requisitos: zzxml zzunescape zztrim zzutf8
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzferiado.sh
+++ b/zz/zzferiado.sh
@@ -11,7 +11,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-11-21
 # Versão: 6
-# Licença: GPLv2
 # Requisitos: zzcarnaval zzcorpuschristi zzdiadasemana zzsextapaixao zzsemacento
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzfilme.sh
+++ b/zz/zzfilme.sh
@@ -8,7 +8,6 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2018-04-16
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzxml zztrim zzecho zzcapitalize zzurldecode zzurlencode
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzfoneletra.sh
+++ b/zz/zzfoneletra.sh
@@ -7,7 +7,6 @@
 # Autor: Rodolfo de Faria <rodolfo faria (a) fujifilm com br>
 # Desde: 2006-10-17
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzmaiusculas
 # Tags: texto, número, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzfrenteverso2pdf.sh
+++ b/zz/zzfrenteverso2pdf.sh
@@ -13,7 +13,6 @@
 # Autor: Lauro Cavalcanti de Sa <laurocdesa (a) gmail com>
 # Desde: 2009-09-17
 # Versão: 4
-# Licença: GPLv2
 # Tags: arquivo, manipulação
 # Nota: requer pdftk
 # ----------------------------------------------------------------------------

--- a/zz/zzfutebol.sh
+++ b/zz/zzfutebol.sh
@@ -27,7 +27,6 @@
 # Autor: Jefferson Fausto Vaz (www.faustovaz.com)
 # Desde: 2014-04-08
 # Versão: 11
-# Licença: GPL
 # Requisitos: zzdatafmt zzjuntalinhas zzpad zzsqueeze zztrim zzutf8 zzxml
 # Tags: internet, futebol, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzgeoip.sh
+++ b/zz/zzgeoip.sh
@@ -7,7 +7,6 @@
 # Autor: Alexandre Magno <alexandre.mbm (a) gmail com>
 # Desde: 2013-07-06
 # Versão: 3
-# Licença: GPLv2
 # Requisitos: zzxml zzipinternet zzecho zzminiurl zztestar
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzglobo.sh
+++ b/zz/zzglobo.sh
@@ -6,7 +6,6 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2017-11-29
 # Versão: 9
-# Licença: GPL
 # Requisitos: zztv
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzgravatar.sh
+++ b/zz/zzgravatar.sh
@@ -22,7 +22,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-06
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzmd5 zzminusculas zztrim
 # Tags: internet, url
 # ----------------------------------------------------------------------------

--- a/zz/zzhexa2str.sh
+++ b/zz/zzhexa2str.sh
@@ -8,7 +8,6 @@
 # Autor: Fernando Mercês <fernando (a) mentebinaria.com.br>
 # Desde: 2012-02-24
 # Versão: 3
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzhexa2str ()

--- a/zz/zzhora.sh
+++ b/zz/zzhora.sh
@@ -15,7 +15,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 5
-# Licença: GPL
 # Tags: tempo, cálculo
 # ----------------------------------------------------------------------------
 zzhora ()

--- a/zz/zzhoracerta.sh
+++ b/zz/zzhoracerta.sh
@@ -13,7 +13,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-03-29
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzjuntalinhas zztrim zzxml
 # Tags: internet, tempo, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzhoramin.sh
+++ b/zz/zzhoramin.sh
@@ -9,7 +9,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-12-05
 # Versão: 4
-# Licença: GPLv2
 # Requisitos: zzhora zztestar
 # Tags: tempo, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzhorariodeverao.sh
+++ b/zz/zzhorariodeverao.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-24
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzcarnaval zzdata zzdiadasemana
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzhoroscopo.sh
+++ b/zz/zzhoroscopo.sh
@@ -12,7 +12,6 @@
 # Autor: Juliano Fernandes, http://julianofernandes.com.br
 # Desde: 2016-05-07
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzsemacento zzminusculas zztrim zzxml
 # Tags: internet, distração, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzhowto.sh
+++ b/zz/zzhowto.sh
@@ -8,7 +8,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-08-27
 # Versão: 3
-# Licença: GPL
 # Requisitos: zztrim zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzhsort.sh
+++ b/zz/zzhsort.sh
@@ -23,7 +23,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-10-07
 # Versão: 2
-# Licença: GPL
 # Requisitos: zztranspor
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzimc.sh
+++ b/zz/zzimc.sh
@@ -7,7 +7,6 @@
 # Autor: Rafael Araújo <rafaelaraujosilva (a) gmail com>
 # Desde: 2015-10-30
 # Versão: 1
-# Licença: GPL
 # Requisitos: zztestar
 # Tags: cálculo
 # ----------------------------------------------------------------------------

--- a/zz/zziostat.sh
+++ b/zz/zziostat.sh
@@ -26,7 +26,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2015-02-17
 # Versão: 2
-# Licença: GPL
 # Tags: sistema, consulta
 # Nota: requer iostat
 # ----------------------------------------------------------------------------

--- a/zz/zzipinternet.sh
+++ b/zz/zzipinternet.sh
@@ -6,7 +6,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2005-09-01
 # Versão: 6
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzipinternet ()

--- a/zz/zzipv6.sh
+++ b/zz/zzipv6.sh
@@ -11,7 +11,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-13
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzjuntalinhas zztestar zzxml
 # Tags: internet, ip
 # ----------------------------------------------------------------------------

--- a/zz/zzit.sh
+++ b/zz/zzit.sh
@@ -23,7 +23,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-02-28
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzsemacento zzutf8 zzxml zzsqueeze zzdatafmt zzlinha
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzjoin.sh
+++ b/zz/zzjoin.sh
@@ -18,7 +18,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-12-05
 # Versão: 1
-# Licença: GPL
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzjoin ()

--- a/zz/zzjquery.sh
+++ b/zz/zzjquery.sh
@@ -15,7 +15,6 @@
 # Autor: Felipe Nascimento Silva Pena <felipensp (a) gmail com>
 # Desde: 2007-12-04
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzcapitalize zzlimpalixo zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzjuntalinhas.sh
+++ b/zz/zzjuntalinhas.sh
@@ -21,7 +21,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-02
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzdos2unix
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzlblank.sh
+++ b/zz/zzlblank.sh
@@ -16,7 +16,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-05-11
 # Versão: 1
-# Licença: GPL
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzlblank ()

--- a/zz/zzlembrete.sh
+++ b/zz/zzlembrete.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-22
 # Versão: 3
-# Licença: GPL
 # Tags: arquivo, utilitário
 # ----------------------------------------------------------------------------
 zzlembrete ()

--- a/zz/zzlibertadores.sh
+++ b/zz/zzlibertadores.sh
@@ -14,7 +14,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-17
 # Versão: 16
-# Licença: GPL
 # Requisitos: zzdatafmt zzjuntalinhas zzlimpalixo zzunescape zzxml
 # Tags: internet, futebol, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzlimpalixo.sh
+++ b/zz/zzlimpalixo.sh
@@ -12,7 +12,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-04-24
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzjuntalinhas
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzlinha.sh
+++ b/zz/zzlinha.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-12-23
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzaleatorio zztestar
 # Tags: arquivo, RANDOM, sed, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzlinux.sh
+++ b/zz/zzlinux.sh
@@ -7,7 +7,6 @@
 # Autor: Diogo Gullit <guuuuuuuuuullit (a) yahoo com br>
 # Desde: 2008-05-01
 # Versão: 2
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzlinux ()

--- a/zz/zzlinuxnews.sh
+++ b/zz/zzlinuxnews.sh
@@ -15,7 +15,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-11-07
 # Versão: 7
-# Licença: GPL
 # Requisitos: zzfeed
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzlocale.sh
+++ b/zz/zzlocale.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2005-06-30
 # Versão: 2
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzlocale ()

--- a/zz/zzlorem.sh
+++ b/zz/zzlorem.sh
@@ -8,7 +8,6 @@
 # Autor: Angelito M. Goulart, www.angelitomg.com
 # Desde: 2012-12-11
 # Versão: 3
-# Licença: GPL
 # Tags: texto, teste
 # ----------------------------------------------------------------------------
 zzlorem ()

--- a/zz/zzloteria.sh
+++ b/zz/zzloteria.sh
@@ -16,7 +16,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-05-18
 # Versão: 17
-# Licença: GPL
 # Requisitos: zzdatafmt zzjuntalinhas zzhoramin zzsqueeze zzunescape zzxml
 # Tags: internet, jogo, consulta
 # Nota: requer unzip

--- a/zz/zzlua.sh
+++ b/zz/zzlua.sh
@@ -13,7 +13,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-09
 # Versão: 2
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzlua ()

--- a/zz/zzmacaddress.sh
+++ b/zz/zzmacaddress.sh
@@ -6,7 +6,6 @@
 # Autor: Adriano Laureano, @sl4ureano
 # Desde: 2018-10-09
 # Versão: 2
-# Licença: GPL
 # Tags: sistema, consulta
 # Nota: (ou) ip ifconfig
 # ----------------------------------------------------------------------------

--- a/zz/zzmacvendor.sh
+++ b/zz/zzmacvendor.sh
@@ -8,7 +8,6 @@
 # Autor: Rafael S. Guimaraes, www.rafaelguimaraes.net
 # Desde: 2016-02-03
 # Versão: 3
-# Licença: GPL
 # Requisitos: zztestar zzcut zzdominiopais
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-08-28
 # Versão: 1
-# Licença: GPL
 # Requisitos: zztrim
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzmaiusculas.sh
+++ b/zz/zzmaiusculas.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-06-12
 # Versão: 2
-# Licença: GPL
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzmaiusculas ()

--- a/zz/zzmariadb.sh
+++ b/zz/zzmariadb.sh
@@ -11,7 +11,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-07-03
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzminusculas zzsemacento zztrim
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzmat.sh
+++ b/zz/zzmat.sh
@@ -36,7 +36,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2011-01-19
 # Versão: 23
-# Licença: GPL
 # Requisitos: zzcalcula zzseq zzaleatorio zztrim zzconverte zztestar
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------

--- a/zz/zzmcd.sh
+++ b/zz/zzmcd.sh
@@ -11,7 +11,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-03-30
 # Versão: 1
-# Licença: GPL
 # Tags: diretório, emulação
 # ----------------------------------------------------------------------------
 zzmcd ()

--- a/zz/zzmd5.sh
+++ b/zz/zzmd5.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-06
 # Versão: 1
-# Licença: GPL
 # Tags: hash, cálculo, emulação
 # Nota: (ou) md5 md5sum
 # ----------------------------------------------------------------------------

--- a/zz/zzminiurl.sh
+++ b/zz/zzminiurl.sh
@@ -10,7 +10,6 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2010-04-26
 # Versão: 7
-# Licença: GPL
 # Tags: internet, url
 # ----------------------------------------------------------------------------
 zzminiurl ()

--- a/zz/zzminusculas.sh
+++ b/zz/zzminusculas.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-06-12
 # Versão: 2
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzminusculas ()

--- a/zz/zzmix.sh
+++ b/zz/zzmix.sh
@@ -24,7 +24,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-11-01
 # Versão: 3
-# Licença: GPL
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzmix ()

--- a/zz/zzmoneylog.sh
+++ b/zz/zzmoneylog.sh
@@ -20,7 +20,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-25
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzcalcula zzdatafmt zzdos2unix
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzmudaprefixo.sh
+++ b/zz/zzmudaprefixo.sh
@@ -10,7 +10,6 @@
 # Autor: Lauro Cavalcanti de Sa <lauro (a) ecdesa com>
 # Desde: 2009-09-21
 # Versão: 2
-# Licença: GPLv2
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzmudaprefixo ()

--- a/zz/zznatal.sh
+++ b/zz/zznatal.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-12-23
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzlinha
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zznerdcast.sh
+++ b/zz/zznerdcast.sh
@@ -24,7 +24,6 @@
 # Autor: Diogo Alexsander Cavilha <diogocavilha (a) gmail com>
 # Desde: 2016-09-19
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzdatafmt zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zznome.sh
+++ b/zz/zznome.sh
@@ -12,7 +12,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2011-04-22
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzsemacento zzminusculas zztrim zzutf8 zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zznomealeatorio.sh
+++ b/zz/zznomealeatorio.sh
@@ -8,7 +8,6 @@
 # Autor: Guilherme Magalhães Gall <gmgall (a) gmail com>
 # Desde: 2013-03-03
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzseq zzaleatorio
 # Tags: sugestão
 # ----------------------------------------------------------------------------

--- a/zz/zznomefoto.sh
+++ b/zz/zznomefoto.sh
@@ -15,7 +15,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-11-10
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzminusculas
 # Tags: arquivo, manipulação
 # Nota: (ou) exiftool exiftime identify

--- a/zz/zznoticiaslinux.sh
+++ b/zz/zznoticiaslinux.sh
@@ -14,7 +14,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-12-17
 # Versão: 11
-# Licença: GPL
 # Requisitos: zzfeed
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zznoticiassec.sh
+++ b/zz/zznoticiassec.sh
@@ -13,7 +13,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2003-07-13
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzfeed
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zznumero.sh
+++ b/zz/zznumero.sh
@@ -31,7 +31,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-05
 # Versão: 13
-# Licença: GPL
 # Requisitos: zzvira zztestar
 # Tags: número, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzora.sh
+++ b/zz/zzora.sh
@@ -7,7 +7,6 @@
 # Autor: Rodrigo Pereira da Cunha <rodrigopc (a) gmail.com>
 # Desde: 2005-11-03
 # Versão: 6
-# Licença: GPL
 # Requisitos: zzurldecode
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzpad.sh
+++ b/zz/zzpad.sh
@@ -17,7 +17,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-05-18
 # Versão: 5
-# Licença: GPL
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzpad ()

--- a/zz/zzpais.sh
+++ b/zz/zzpais.sh
@@ -16,7 +16,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-29
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzlinha zzpad
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzpalpite.sh
+++ b/zz/zzpalpite.sh
@@ -11,7 +11,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2012-06-03
 # Versão: 6
-# Licença: GPL
 # Requisitos: zzaleatorio zzminusculas zzsemacento zzseq zzaleatorio
 # Tags: jogo, distração
 # ----------------------------------------------------------------------------

--- a/zz/zzpascoa.sh
+++ b/zz/zzpascoa.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-23
 # Versão: 1
-# Licença: GPL
 # Tags: data
 # ----------------------------------------------------------------------------
 zzpascoa ()

--- a/zz/zzpgsql.sh
+++ b/zz/zzpgsql.sh
@@ -11,7 +11,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-05-11
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzjuntalinhas zzsqueeze zztrim zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzphp.sh
+++ b/zz/zzphp.sh
@@ -13,7 +13,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-06
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzunescape
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzplay.sh
+++ b/zz/zzplay.sh
@@ -16,7 +16,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-13
 # Versão: 6
-# Licença: GPL
 # Requisitos: zzextensao zzminusculas zzunescape zzxml
 # Tags: aúdio
 # Nota: (ou) afplay play mplayer cvlc avplay ffplay mpg321 mpg123 ogg123

--- a/zz/zzporcento.sh
+++ b/zz/zzporcento.sh
@@ -18,7 +18,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-12-11
 # Versão: 6
-# Licença: GPL
 # Requisitos: zztestar
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------

--- a/zz/zzporta.sh
+++ b/zz/zzporta.sh
@@ -10,7 +10,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-11-15
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzjuntalinhas
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzpronuncia.sh
+++ b/zz/zzpronuncia.sh
@@ -6,7 +6,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-04-10
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzplay zzunescape
 # Tags: internet, aúdio
 # Nota: opcional say

--- a/zz/zzquimica.sh
+++ b/zz/zzquimica.sh
@@ -10,7 +10,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-22
 # Versão: 7
-# Licença: GPL
 # Requisitos: zzcapitalize zzwikipedia zzxml zzpad
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzramones.sh
+++ b/zz/zzramones.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-07-24
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzlinha
 # Tags: internet, música, distração
 # ----------------------------------------------------------------------------

--- a/zz/zzrastreamento.sh
+++ b/zz/zzrastreamento.sh
@@ -8,7 +8,6 @@
 # Autor: Frederico Freire Boaventura <anonymous (a) galahad com br>
 # Desde: 2007-06-25
 # Versão: 4
-# Licença: GPL
 # Requisitos: zztrim zzunescape zzxml zzjuntalinhas
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzrepete.sh
+++ b/zz/zzrepete.sh
@@ -8,7 +8,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-04-12
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzseq
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zzromanos.sh
+++ b/zz/zzromanos.sh
@@ -10,7 +10,6 @@
 # Autor: Guilherme Magalhães Gall <gmgall (a) gmail com>
 # Desde: 2011-07-19
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzmaiusculas zztac
 # Tags: número, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzrot13.sh
+++ b/zz/zzrot13.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-07-23
 # Versão: 1
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzrot13 ()

--- a/zz/zzrot47.sh
+++ b/zz/zzrot47.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-07-23
 # Versão: 1
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzrot47 ()

--- a/zz/zzrpmfind.sh
+++ b/zz/zzrpmfind.sh
@@ -9,7 +9,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-02-22
 # Versão: 3
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzrpmfind ()

--- a/zz/zzsecurity.sh
+++ b/zz/zzsecurity.sh
@@ -11,7 +11,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-12-23
 # Versão: 13
-# Licença: GPL
 # Requisitos: zzminusculas zzfeed zztac
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzsemacento.sh
+++ b/zz/zzsemacento.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2010-05-24
 # Versão: 1
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzsemacento ()

--- a/zz/zzsenha.sh
+++ b/zz/zzsenha.sh
@@ -16,7 +16,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-11-07
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzaleatorio
 # Tags: sugestão
 # ----------------------------------------------------------------------------

--- a/zz/zzseq.sh
+++ b/zz/zzseq.sh
@@ -17,7 +17,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-12-06
 # Versão: 1
-# Licença: GPL
 # Requisitos: zztestar
 # Tags: seq, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzsextapaixao.sh
+++ b/zz/zzsextapaixao.sh
@@ -9,7 +9,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-11-21
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzdata zzpascoa
 # Tags: data
 # ----------------------------------------------------------------------------

--- a/zz/zzsheldon.sh
+++ b/zz/zzsheldon.sh
@@ -7,7 +7,6 @@
 # Autor: Jonas Gentina, <jgentina (a) gmail com>
 # Desde: 2015-09-25
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzaleatorio zztrim zzjuntalinhas zzlinha zzsqueeze zzxml zzutf8
 # Tags: internet, distação
 # ----------------------------------------------------------------------------

--- a/zz/zzshuffle.sh
+++ b/zz/zzshuffle.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-06-19
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzaleatorio
 # Tags: shuffle, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzsigla.sh
+++ b/zz/zzsigla.sh
@@ -8,7 +8,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-02-21
 # Versão: 3
-# Licença: GPL
 # Requisitos: zztrim
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------

--- a/zz/zzsplit.sh
+++ b/zz/zzsplit.sh
@@ -23,7 +23,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-11-10
 # Versão: 3
-# Licença: GPL
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzsplit ()

--- a/zz/zzsqueeze.sh
+++ b/zz/zzsqueeze.sh
@@ -17,7 +17,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-09-24
 # Versão: 1
-# Licença: GPL
 # Tags: squeeze, emulação
 # ----------------------------------------------------------------------------
 zzsqueeze ()

--- a/zz/zzss.sh
+++ b/zz/zzss.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-06-12
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzaleatorio zztrim
 # Tags: screen saver, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzstr2hexa.sh
+++ b/zz/zzstr2hexa.sh
@@ -8,7 +8,6 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2012-03-30
 # Versão: 9
-# Licença: GPL
 # Requisitos: zztrim
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzsubway.sh
+++ b/zz/zzsubway.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-12-02
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzshuffle zzaleatorio
 # Tags: sugestão
 # ----------------------------------------------------------------------------

--- a/zz/zztabuada.sh
+++ b/zz/zztabuada.sh
@@ -18,7 +18,6 @@
 # Autor: Kl0nEz <kl0nez (a) wifi org br>
 # Desde: 2011-08-23
 # Versão: 6
-# Licença: GPLv2
 # Requisitos: zzseq zztestar
 # Tags: número, tabela
 # ----------------------------------------------------------------------------

--- a/zz/zztac.sh
+++ b/zz/zztac.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-24
 # Versão: 1
-# Licença: GPL
 # Tags: tac, emulação
 # ----------------------------------------------------------------------------
 zztac ()

--- a/zz/zztempo.sh
+++ b/zz/zztempo.sh
@@ -47,7 +47,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-02-19
 # Versão: 2
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zztempo ()

--- a/zz/zztestar.sh
+++ b/zz/zztestar.sh
@@ -34,7 +34,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-03-14
 # Versão: 2
-# Licença: GPL
 # Tags: número, teste
 # ----------------------------------------------------------------------------
 zztestar ()

--- a/zz/zztimer.sh
+++ b/zz/zztimer.sh
@@ -27,7 +27,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-01-25
 # Versão: 5
-# Licença: GPL
 # Requisitos: zzcut
 # Tags: tempo
 # ----------------------------------------------------------------------------

--- a/zz/zztop.sh
+++ b/zz/zztop.sh
@@ -29,7 +29,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-07-19
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzcolunar zzjuntalinhas zzsqueeze zztac zztrim zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zztranspor.sh
+++ b/zz/zztranspor.sh
@@ -21,7 +21,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-09-03
 # Versão: 1
-# Licença: GPL
 # Requisitos: zztrim
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------

--- a/zz/zztrim.sh
+++ b/zz/zztrim.sh
@@ -19,7 +19,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2015-03-05
 # Versão: 3
-# Licença: GPL
 # Tags: trim, emulação
 # ----------------------------------------------------------------------------
 zztrim ()

--- a/zz/zztrocaarquivos.sh
+++ b/zz/zztrocaarquivos.sh
@@ -6,7 +6,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-06-12
 # Versão: 2
-# Licença: GPL
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zztrocaarquivos ()

--- a/zz/zztrocaextensao.sh
+++ b/zz/zztrocaextensao.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-15
 # Versão: 1
-# Licença: GPL
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zztrocaextensao ()

--- a/zz/zztrocapalavra.sh
+++ b/zz/zztrocapalavra.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-04
 # Versão: 2
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zztrocapalavra ()

--- a/zz/zztv.sh
+++ b/zz/zztv.sh
@@ -23,7 +23,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-02-19
 # Versão: 14
-# Licença: GPL
 # Requisitos: zzcolunar zzdatafmt zzjuntalinhas zzpad zzsqueeze zztrim zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------

--- a/zz/zzunescape.sh
+++ b/zz/zzunescape.sh
@@ -13,7 +13,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-03
 # Versão: 3
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzunescape ()

--- a/zz/zzunicode.sh
+++ b/zz/zzunicode.sh
@@ -12,7 +12,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-10-13
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzcolunar zzlimpalixo zztrim zzunescape
 # Tags: internet, texto, tabela
 # ----------------------------------------------------------------------------

--- a/zz/zzunicode2ascii.sh
+++ b/zz/zzunicode2ascii.sh
@@ -8,7 +8,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-06
 # Versão: 1
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzunicode2ascii ()

--- a/zz/zzuniq.sh
+++ b/zz/zzuniq.sh
@@ -9,7 +9,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-06-22
 # Versão: 3
-# Licença: GPL
 # Tags: uniq, emulação
 # ----------------------------------------------------------------------------
 zzuniq ()

--- a/zz/zzunix2dos.sh
+++ b/zz/zzunix2dos.sh
@@ -7,7 +7,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzunix2dos ()

--- a/zz/zzurldecode.sh
+++ b/zz/zzurldecode.sh
@@ -9,7 +9,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-03-14
 # Versão: 2
-# Licença: GPL
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzurldecode ()

--- a/zz/zzurlencode.sh
+++ b/zz/zzurlencode.sh
@@ -16,7 +16,6 @@
 # Autor: Guilherme Magalhães Gall <gmgall (a) gmail com>
 # Desde: 2013-03-19
 # Versão: 4
-# Licença: GPL
 # Requisitos: zzmaiusculas
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzutf8.sh
+++ b/zz/zzutf8.sh
@@ -11,7 +11,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2015-03-21
 # Versão: 2
-# Licença: GPL
 # Requisitos: zzencoding
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------

--- a/zz/zzvdp.sh
+++ b/zz/zzvdp.sh
@@ -13,7 +13,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-25
 # Versão: 7
-# Licença: GPL
 # Requisitos: zzunescape zzxml
 # Tags: internet, distração
 # ----------------------------------------------------------------------------

--- a/zz/zzvds.sh
+++ b/zz/zzvds.sh
@@ -13,7 +13,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-05-07
 # Versão: 1
-# Licença: GPL
 # Requisitos: zzjuntalinhas zztrim zzunescape zzxml
 # Tags: internet, distração
 # ----------------------------------------------------------------------------

--- a/zz/zzvira.sh
+++ b/zz/zzvira.sh
@@ -10,7 +10,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2010-05-24
 # Versão: 3
-# Licença: GPL
 # Requisitos: zzsemacento zzminusculas
 # Tags: rev, emulação
 # ----------------------------------------------------------------------------

--- a/zz/zzwc.sh
+++ b/zz/zzwc.sh
@@ -26,7 +26,6 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-03-10
 # Versão: 1
-# Licença: GPL
 # Tags: contagem, emulação
 # ----------------------------------------------------------------------------
 zzwc ()

--- a/zz/zzwikipedia.sh
+++ b/zz/zzwikipedia.sh
@@ -14,7 +14,6 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-10-28
 # Versão: 4
-# Licença: GPL
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzwikipedia ()

--- a/zz/zzxml.sh
+++ b/zz/zzxml.sh
@@ -27,7 +27,6 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-03
 # Versão: 15
-# Licença: GPL
 # Requisitos: zzjuntalinhas zzuniq zzunescape
 # Tags: parser
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
A retirada do campo 'Licença' evita ambiguidade com a licença explicitamente citada no core, e para tanto o utilitário ` Nanny ` passa a verificar as novas funções caso tragam esse campo no cabeçalho, e o utilitário ` Metadata ` não pesquisará esse campo mais.