### PR TITLE
adicionado default.nix para empacotamento para Nix/NixOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,55 @@
+with builtins; # funções como toString
+{ pkgs ? import <nixpkgs> { }
+, color ? true
+, browserName ? "links2"
+, browserPkg ? {
+  "lynx" = pkgs.lynx;
+  "links" = pkgs.links;
+  "links2" = pkgs.links2;
+  "elinks" = pkgs.elinks;
+  "w3m" = pkgs.w3m;
+}.${browserName} }:
+let
+  ZZCOR_DFT = if color then 1 else 0;
+  drv = pkgs.stdenv.mkDerivation {
+    name = "funcoeszz-source";
+    src = ./.;
+    installPhase = ''
+      mkdir -p $out/opt
+      cp -r $src $out/opt/funcoeszz
+    '';
+  };
+  deps = with pkgs; [ browserPkg bc ];
+  mainbin = pkgs.writeShellScript "zz" ''
+    # Deixa os binários dependentes acessíveis
+    PATH=$PATH:${pkgs.lib.makeBinPath deps}
+    # Permite configurar suporte a cor pelo parâmetro do pacote
+    ZZCOR_DFT=${toString ZZCOR_DFT}
+    # Onde estão as funções?
+    ZZDIR_DFT="${drv}/opt/funcoeszz/zz"
+    # Chama o script com os parâmetros que vierem
+    ${drv}/opt/funcoeszz/funcoeszz $*
+  '';
+in pkgs.stdenv.mkDerivation {
+  name = "funcoeszz";
+  phases = [ "installPhase" ]; # Ignora o fato de eu não ter passado um src
+  installPhase = ''
+    # Criar a pasta dos binários
+    mkdir -p $out/bin
+    # Cada um dos utilitários tem seu script de entrypoint que consequentemente vira um comando sem ter que mexer na bashrc, e pode ser instalado globalmente
+    for fn in $(ls -1 ${drv}/opt/funcoeszz/zz | sed 's;.sh$;;g'); do
+      echo Gerando script $fn
+      bin=$out/bin/$fn
+      echo '#!/usr/bin/env ${pkgs.bash}/bin/bash' >> $bin
+      echo "${mainbin} $fn %" | sed 's;%;$*;g' >> $bin
+      chmod +x $bin
+    done
+    # Link do comando zz que engloba todos os outros
+    ln -s ${mainbin} $out/bin/zz
+    # Manpage
+    mkdir -p $out/share/man/man1
+    cp ${drv}/opt/funcoeszz/manpage/manpage.man $out/share/man/man1/funcoeszz.1
+    # shellcheck acusa os $* mas a minha intenção é exatamente deixar os argumentos expandirem
+    # ${pkgs.shellcheck}/bin/shellcheck -s bash $out/bin/*
+  '';
+}

--- a/default.nix
+++ b/default.nix
@@ -24,11 +24,11 @@ let
     # Deixa os binários dependentes acessíveis
     PATH=$PATH:${pkgs.lib.makeBinPath deps}
     # Permite configurar suporte a cor pelo parâmetro do pacote
-    ZZCOR_DFT=${toString ZZCOR_DFT}
+    export ZZCOR=${toString ZZCOR_DFT}
     # Onde estão as funções?
-    ZZDIR_DFT="${drv}/opt/funcoeszz/zz"
+    export ZZDIR="${drv}/opt/funcoeszz/zz"
     # Chama o script com os parâmetros que vierem
-    ${drv}/opt/funcoeszz/funcoeszz $*
+    ${drv}/opt/funcoeszz/funcoeszz "$@"
   '';
 in pkgs.stdenv.mkDerivation {
   name = "funcoeszz";
@@ -41,7 +41,7 @@ in pkgs.stdenv.mkDerivation {
       echo Gerando script $fn
       bin=$out/bin/$fn
       echo '#!/usr/bin/env ${pkgs.bash}/bin/bash' >> $bin
-      echo "${mainbin} $fn %" | sed 's;%;$*;g' >> $bin
+      echo "${mainbin} $fn %" | sed 's;%;"$@";g' >> $bin
       chmod +x $bin
     done
     # Link do comando zz que engloba todos os outros
@@ -49,7 +49,6 @@ in pkgs.stdenv.mkDerivation {
     # Manpage
     mkdir -p $out/share/man/man1
     cp ${drv}/opt/funcoeszz/manpage/manpage.man $out/share/man/man1/funcoeszz.1
-    # shellcheck acusa os $* mas a minha intenção é exatamente deixar os argumentos expandirem
-    # ${pkgs.shellcheck}/bin/shellcheck -s bash $out/bin/*
+    ${pkgs.shellcheck}/bin/shellcheck -s bash $out/bin/*
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ with builtins; # funções como toString
   "w3m" = pkgs.w3m;
 }.${browserName} }:
 let
-  ZZCOR_DFT = if color then 1 else 0;
+  ZZCOR = if color then 1 else 0;
   drv = pkgs.stdenv.mkDerivation {
     name = "funcoeszz-source";
     src = ./.;
@@ -24,7 +24,7 @@ let
     # Deixa os binários dependentes acessíveis
     PATH=$PATH:${pkgs.lib.makeBinPath deps}
     # Permite configurar suporte a cor pelo parâmetro do pacote
-    export ZZCOR=${toString ZZCOR_DFT}
+    export ZZCOR=${toString ZZCOR}
     # Onde estão as funções?
     export ZZDIR="${drv}/opt/funcoeszz/zz"
     # Chama o script com os parâmetros que vierem
@@ -50,5 +50,8 @@ in pkgs.stdenv.mkDerivation {
     mkdir -p $out/share/man/man1
     cp ${drv}/opt/funcoeszz/manpage/manpage.man $out/share/man/man1/funcoeszz.1
     ${pkgs.shellcheck}/bin/shellcheck -s bash $out/bin/*
+    # Referencia ao repo na saída
+    mkdir -p $out/opt
+    ln -s ${drv}/opt/funcoeszz $out/opt/funcoeszz
   '';
 }

--- a/funcoeszz
+++ b/funcoeszz
@@ -40,10 +40,11 @@ ZZUTF=1
 # A configuração também pode ser feita diretamente neste arquivo, se você
 # puder fazer alterações nele.
 #
-ZZCOR_DFT=1                       # colorir mensagens? 1 liga, 0 desliga
-ZZPATH_DFT="/usr/bin/funcoeszz"   # rota absoluta deste arquivo
-ZZDIR_DFT="$HOME/zz"              # rota absoluta do diretório com as funções
-ZZTMPDIR_DFT="${TMPDIR:-/tmp}"    # diretório temporário
+ME=$(realpath $(realpath $0))          # caminho para este script, $0 pode ser um symlink em caminho relativo
+ZZCOR_DFT=1                            # colorir mensagens? 1 liga, 0 desliga
+ZZDIR_DFT="$(dirname $ME)"             # rota absoluta do diretorio com as funcoes
+ZZPATH_DFT="$ZZDIR_DFT/zz"             # rota absoluta deste arquivo
+ZZTMPDIR_DFT="${TMPDIR:-/tmp}"         # diretório temporário
 #
 #
 ##############################################################################
@@ -61,6 +62,11 @@ ZZTMPDIR_DFT="${TMPDIR:-/tmp}"    # diretório temporário
 ZZSEDURL='s| |+|g;s|&|%26|g;s|@|%40|g'
 ZZCODIGOCOR='36;1'            # use zzcores para ver os códigos
 ZZBASE='zzajuda zztool zzzz'  # Funções essenciais, guardadas neste script
+
+# Lidando com os comandos se for chamado por link simbólico ala busybox
+if [ $(basename "$0") != "funcoeszz" ] && [ "$0" != "clitest" ]; then
+    exec "$(realpath $0)" $(basename "$0") "$@"
+fi
 
 #
 ### Truques para descobrir a localização deste arquivo no sistema
@@ -1159,7 +1165,6 @@ unset zz_nome
 unset zz_off
 unset zz_sed
 unset -f _extrai_ajuda
-
 
 ##----------------------------------------------------------------------------
 ## Lidando com a chamada pelo executável

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,38 @@
+{pkgs ? import <nixpkgs> {}}:
+let
+  clitest = pkgs.stdenv.mkDerivation rec {
+    name = "clitest";
+    version = "0.4.0";
+    src = builtins.fetchTarball {
+      url = "https://github.com/aureliojargas/clitest/archive/0.4.0.tar.gz";
+      sha256 = "sha256:1p745mxiq3hgi3ywfljs5sa1psi06awwjxzw0j9c2xx1b09yqv4a";
+    };
+    buildPhase = "";
+    installPhase = ''
+      mkdir -p $out/bin
+      cp $src/clitest $out/bin/clitest
+      chmod +x $out/bin/clitest
+    '';
+  };
+  funcoeszz = pkgs.callPackage ./default.nix {};
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    # dependencia de execução
+    bc
+    curl
+    gawk
+    gnused
+    ncurses
+    # dependencia de teste
+    perl
+    w3m
+    clitest
+  ];
+  shellHook = ''
+    zzroot=$(pwd)
+    function testador {
+      $zzroot/testador/run "$@"
+    }
+  '';
+}

--- a/testador/run
+++ b/testador/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run - run tests
 #
 # Usage:

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 2010-12-22
 # Aurelio Marinho Jargas
 #


### PR DESCRIPTION
Eu empacotei o funçõeszz para o Nix.

Conheci o projeto a poucos dias e to curtindo bastante.

Do jeito que tá eu especifiquei dependência do `bc` e de um dos navegadores suportados (lynx, links, links2, elinks ou w3m) podendo especificar pelo nome e ele já pega o pacote no nixpkgs também podendo passar por cima especificando quem sabe um outro navegador TUI que pode ser usado pelo funções zz. Por padrão ele usa o links2 e as cores estão ativadas. As variáveis são passadas por um script que encapsula o funções zz (zz) e que também tem scripts gerados para cada comando (zz alguma coisa).

Também coloquei a manpage no pacote podendo ser acessada pelo `man funcoeszz`.

Tem também uma linha que chama o shellcheck nos scripts que tá comentada. O motivo é que ele dá warning dos `$*`, o que era minha intenção mesmo hehe.