### PR TITLE
Remove suporte a arquivos sem extensão .sh

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -1064,9 +1064,6 @@ then
 	do
 		zz_arquivo="${ZZDIR%/}"/$zz_nome.sh
 
-		# Suporte legado aos arquivos sem a extensão .sh
-		test -r "$zz_arquivo" || zz_arquivo="${zz_arquivo%.sh}"
-
 		sed 1q "$zz_arquivo"
 		echo "# $zz_nome"
 		sed 1d "$zz_arquivo"
@@ -1092,21 +1089,8 @@ while read zz_nome
 do
 	zz_arquivo="${ZZDIR%/}"/$zz_nome.sh
 
-	# Se o arquivo não existir, tenta encontrá-lo sem a extensao .sh.
-	# No futuro este suporte às funções sem extensão pode ser removido.
-	if ! test -r "$zz_arquivo"
-	then
-		if test -r "${zz_arquivo%.sh}"
-		then
-			# Não achei zzfoo.sh, mas achei o zzfoo
-			# Vamos usá-lo então.
-			zz_arquivo="${zz_arquivo%.sh}"
-		else
-			# Não achei zzfoo.sh nem zzfoo
-			# Cancelaremos o carregamento desta função.
-			continue
-		fi
-	fi
+	# Pula o carregamento dessa função se o arquivo não existir
+	test -r "$zz_arquivo" || continue
 
 	# Inclui a função na shell atual
 	. "$zz_arquivo"


### PR DESCRIPTION
Todas as funções da pasta `zz` possuem a extensão `.sh`.

Este código nunca era utilizado.