### PR TITLE
util/requisitos.sh: Detecta função fazendo autoreferência

### DIFF
--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -192,13 +192,6 @@ do
 done
 
 eco ----------------------------------------------------------------
-eco "* Funções que citam a si mesmas no campo Requisitos:"
-for f in zz/*.sh off/*.sh
-do
- grep "^# Requisitos:.*$(basename $f .sh)" $f > /dev/null && echo $f
-done
-
-eco ----------------------------------------------------------------
 eco "* Funções com cabeçalho >78 colunas"
 for f in zz/*.sh off/*.sh
 do

--- a/util/requisitos.sh
+++ b/util/requisitos.sh
@@ -3,10 +3,11 @@
 # Aurelio Jargas
 #
 # Mostra quando uma função está faltando ou sobrando na linha Requisitos:
-# 
+#
 # $ ./requisitos.sh
 # zzcarnaval: # Requisitos: zzpascoa
 # zzfeed: Função listada mas não utilizada: zzbeep
+# zzdata.sh: Função lista a si própria como requisito
 #
 
 cd $(dirname "$0") || exit 1
@@ -34,6 +35,14 @@ do
 		egrep -v 'zztool|zzzz' |
 		sort |
 		uniq)
+
+	# REQUER A SI MESMA
+	# Não faz sentido uma função colocar a si mesma como requisito
+	for req in $requisitos
+	do
+		test "$req.sh" = "$f" &&
+			echo "$f: Função lista a si própria como requisito"
+	done
 
 	# SOBRANDO
 	# Funções listadas em Requisitos: mas não utilizadas


### PR DESCRIPTION
Não é válido uma função declarar ela mesma como requisito, mesmo que
ela faça chamadas recursivas a si mesma.

A ideia dos requisitos são dependências em outras funções, pois a
função atual já está disponível, não é relevante essa informação.

Havia esta mesma verificação na Nanny, ela foi removida. A ideia é que
este script é o especialista em requisitos, e sabe melhor como detectar
os problemas.