### PR TITLE
Requisitos: Agora também lista as funções-base: zzzz, zztool, zzajuda

### DIFF
--- a/util/requisitos.sh
+++ b/util/requisitos.sh
@@ -12,11 +12,6 @@
 
 cd $(dirname "$0") || exit 1
 
-base="\
-zzzz
-zztool
-zzajuda"
-
 cd ../zz
 for f in zz*
 do
@@ -32,7 +27,6 @@ do
 		grep 'zz[a-z]' |
 		grep -v '()$' |
 		egrep -o 'zz[a-z0-9]+' |
-		egrep -v 'zztool|zzzz' |
 		sort |
 		uniq)
 
@@ -57,9 +51,6 @@ do
 		# Se o requisito não for uma função zz, ignore
 		echo $req | grep ^zz >/dev/null ||
 			{ echo "$f: $req não é uma funcão zz, registre em 'Notas'" ; continue; }
-
-		echo "$base" | grep -w $req >/dev/null &&
-			echo "$f: Função-base, não deve estar em Requisitos: $req"
 
 		echo "$encontradas" | grep -w $req >/dev/null ||
 			echo "$f: Função listada mas não utilizada: $req"

--- a/zz/zzaleatorio.sh
+++ b/zz/zzaleatorio.sh
@@ -12,7 +12,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-13
 # Versão: 5
-# Requisitos: zzvira
+# Requisitos: zzzz zztool zzvira
 # Tags: número, RANDOM, emulação
 # ----------------------------------------------------------------------------
 zzaleatorio ()

--- a/zz/zzalfabeto.sh
+++ b/zz/zzalfabeto.sh
@@ -28,7 +28,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-07-23
 # Versão: 6
-# Requisitos: zzmaiusculas zztrim
+# Requisitos: zzzz zztool zzmaiusculas zztrim
 # Tags: texto, tabela
 # ----------------------------------------------------------------------------
 zzalfabeto ()

--- a/zz/zzalinhar.sh
+++ b/zz/zzalinhar.sh
@@ -19,7 +19,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-05-23
 # Versão: 4
-# Requisitos: zzpad zztrim zzwc
+# Requisitos: zzzz zztool zzpad zztrim zzwc
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzalinhar ()

--- a/zz/zzansi2html.sh
+++ b/zz/zzansi2html.sh
@@ -11,6 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-09-02
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzansi2html ()

--- a/zz/zzarrumacidade.sh
+++ b/zz/zzarrumacidade.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 3
-# Requisitos: zzcapitalize
+# Requisitos: zzzz zztool zzcapitalize
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzarrumacidade ()

--- a/zz/zzarrumanome.sh
+++ b/zz/zzarrumanome.sh
@@ -14,7 +14,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-07-23
 # Versão: 1
-# Requisitos: zzminusculas
+# Requisitos: zzzz zztool zzminusculas
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzarrumanome ()

--- a/zz/zzascii.sh
+++ b/zz/zzascii.sh
@@ -10,7 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-12-06
 # Versão: 6
-# Requisitos: zzseq zzcolunar
+# Requisitos: zzzz zztool zzseq zzcolunar
 # Tags: texto, tabela
 # ----------------------------------------------------------------------------
 zzascii ()

--- a/zz/zzbeep.sh
+++ b/zz/zzbeep.sh
@@ -10,6 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-04-24
 # Versão: 1
+# Requisitos: zzzz
 # Tags: utilitário, emulação
 # ----------------------------------------------------------------------------
 zzbeep ()

--- a/zz/zzbicho.sh
+++ b/zz/zzbicho.sh
@@ -12,7 +12,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2012-08-27
 # Versão: 4
-# Requisitos: zztrim
+# Requisitos: zzzz zztool zztrim
 # Tags: jogo, consulta
 # ----------------------------------------------------------------------------
 zzbicho ()

--- a/zz/zzbissexto.sh
+++ b/zz/zzbissexto.sh
@@ -8,7 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-21
 # Versão: 1
-# Requisitos: zztestar
+# Requisitos: zzzz zztool zztestar
 # Tags: data
 # ----------------------------------------------------------------------------
 zzbissexto ()

--- a/zz/zzblist.sh
+++ b/zz/zzblist.sh
@@ -6,7 +6,7 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2008-10-16
 # Versão: 5
-# Requisitos: zztestar
+# Requisitos: zzzz zztool zztestar
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzblist ()

--- a/zz/zzbraille.sh
+++ b/zz/zzbraille.sh
@@ -30,7 +30,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-05-26
 # Versão: 6
-# Requisitos: zzminusculas zzmaiusculas zzcapitalize zzseq zztestar
+# Requisitos: zzzz zztool zzminusculas zzmaiusculas zzcapitalize zzseq zztestar
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzbraille ()

--- a/zz/zzbrasileirao.sh
+++ b/zz/zzbrasileirao.sh
@@ -21,7 +21,7 @@
 # Autor: Alexandre Brodt Fernandes, www.xalexandre.com.br
 # Desde: 2011-05-28
 # Versão: 27
-# Requisitos: zzecho zzjuntalinhas zzpad zzxml
+# Requisitos: zzzz zztool zzecho zzjuntalinhas zzpad zzxml
 # Tags: internet, futebol, consulta
 # ----------------------------------------------------------------------------
 zzbrasileirao ()

--- a/zz/zzbyte.sh
+++ b/zz/zzbyte.sh
@@ -10,7 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-03-01
 # Versão: 1
-# Requisitos: zzmaiusculas
+# Requisitos: zzzz zztool zzmaiusculas
 # Tags: número, conversão
 # ----------------------------------------------------------------------------
 zzbyte ()

--- a/zz/zzcalcula.sh
+++ b/zz/zzcalcula.sh
@@ -13,6 +13,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-04
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------
 zzcalcula ()

--- a/zz/zzcalculaip.sh
+++ b/zz/zzcalculaip.sh
@@ -10,7 +10,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2005-09-01
 # Versão: 2
-# Requisitos: zzconverte zztestar
+# Requisitos: zzzz zztool zzconverte zztestar
 # Tags: ip, cálculo
 # ----------------------------------------------------------------------------
 zzcalculaip ()

--- a/zz/zzcapitalize.sh
+++ b/zz/zzcapitalize.sh
@@ -17,7 +17,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 5
-# Requisitos: zzminusculas
+# Requisitos: zzzz zztool zzminusculas
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzcapitalize ()

--- a/zz/zzcaracoroa.sh
+++ b/zz/zzcaracoroa.sh
@@ -6,7 +6,7 @@
 # Autor: Angelito M. Goulart, www.angelitomg.com
 # Desde: 2012-12-06
 # Versão: 1
-# Requisitos: zzaleatorio
+# Requisitos: zzzz zzaleatorio
 # Tags: RANDOM, emulação
 # ----------------------------------------------------------------------------
 zzcaracoroa ()

--- a/zz/zzcarnaval.sh
+++ b/zz/zzcarnaval.sh
@@ -9,7 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-23
 # Versão: 1
-# Requisitos: zzdata zzpascoa
+# Requisitos: zzzz zztool zzdata zzpascoa
 # Tags: data
 # ----------------------------------------------------------------------------
 zzcarnaval ()

--- a/zz/zzcep.sh
+++ b/zz/zzcep.sh
@@ -9,7 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-11-08
 # Versão: 4
-# Requisitos: zzsemacento zzminusculas zzxml zzjuntalinhas zzcolunar zztrim zzpad
+# Requisitos: zzzz zztool zzsemacento zzminusculas zzxml zzjuntalinhas zzcolunar zztrim zzpad
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzcep ()

--- a/zz/zzchavepgp.sh
+++ b/zz/zzchavepgp.sh
@@ -8,6 +8,7 @@
 # Autor: Rodrigo Missiaggia
 # Desde: 2001-10-01
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzchavepgp ()

--- a/zz/zzchecamd5.sh
+++ b/zz/zzchecamd5.sh
@@ -7,7 +7,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-10-31
 # Versão: 3
-# Requisitos: zzmd5
+# Requisitos: zzzz zztool zzmd5
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzchecamd5 ()

--- a/zz/zzcidade.sh
+++ b/zz/zzcidade.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 4
-# Requisitos: zzlinha zztrim zzlimpalixo
+# Requisitos: zzzz zztool zzlinha zztrim zzlimpalixo
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzcidade ()

--- a/zz/zzcinclude.sh
+++ b/zz/zzcinclude.sh
@@ -8,6 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-12-15
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: arquivo, consulta
 # Nota: requer cpp
 # ----------------------------------------------------------------------------

--- a/zz/zzcinemais.sh
+++ b/zz/zzcinemais.sh
@@ -9,7 +9,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-08-25
 # Versão: 11
-# Requisitos: zzecho zzjuntalinhas zztrim zzutf8 zzxml
+# Requisitos: zzzz zztool zzecho zzjuntalinhas zztrim zzutf8 zzxml
 # Tags: internet, cinema
 # ----------------------------------------------------------------------------
 zzcinemais ()

--- a/zz/zzcineuci.sh
+++ b/zz/zzcineuci.sh
@@ -8,7 +8,7 @@
 # Autor: Rodrigo Pereira da Cunha <rodrigopc (a) gmail.com>
 # Desde: 2009-05-04
 # Versão: 10
-# Requisitos: zzunescape zztrim zzcolunar
+# Requisitos: zzzz zztool zzunescape zztrim zzcolunar
 # Tags: internet, cinema
 # ----------------------------------------------------------------------------
 zzcineuci ()

--- a/zz/zzclassnum.sh
+++ b/zz/zzclassnum.sh
@@ -7,7 +7,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-05-12
 # Versão: 2
-# Requisitos: zzdivisores zzmat zztestar zzvira
+# Requisitos: zzzz zztool zzdivisores zzmat zztestar zzvira
 # Tags: número
 # ----------------------------------------------------------------------------
 zzclassnum ()

--- a/zz/zzcnpj.sh
+++ b/zz/zzcnpj.sh
@@ -13,7 +13,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-12-23
 # Versão: 4
-# Requisitos: zzaleatorio
+# Requisitos: zzzz zztool zzaleatorio
 # Tags: internet, cálculo, manipulação
 # ----------------------------------------------------------------------------
 zzcnpj ()

--- a/zz/zzcodchar.sh
+++ b/zz/zzcodchar.sh
@@ -18,7 +18,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-12-07
 # Versão: 3
-# Requisitos: zztrim zzpad
+# Requisitos: zzzz zztool zztrim zzpad
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzcodchar ()

--- a/zz/zzcodq.sh
+++ b/zz/zzcodq.sh
@@ -12,7 +12,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-07
 # Versão: 1
-# Requisitos: zzcolunar zzcut zzjuntalinhas zzmaiusculas zzwc zzxml
+# Requisitos: zzzz zztool zzcolunar zzcut zzjuntalinhas zzmaiusculas zzwc zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzcodq ()

--- a/zz/zzcoin.sh
+++ b/zz/zzcoin.sh
@@ -12,7 +12,7 @@
 # Autor: Tárcio Zemel <tarciozemel (a) gmail com>
 # Desde: 2014-03-24
 # Versão: 7
-# Requisitos: zzmaiusculas zznumero zzpad zzsemacento zzxml
+# Requisitos: zzzz zztool zzmaiusculas zznumero zzpad zzsemacento zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzcoin ()

--- a/zz/zzcolunar.sh
+++ b/zz/zzcolunar.sh
@@ -38,7 +38,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-04-24
 # Versão: 5
-# Requisitos: zzalinhar zztrim
+# Requisitos: zzzz zztool zzalinhar zztrim
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzcolunar ()

--- a/zz/zzconfere.sh
+++ b/zz/zzconfere.sh
@@ -31,7 +31,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-11-25
 # Versão: 2
-# Requisitos: zzhsort zzloteria
+# Requisitos: zzzz zztool zzhsort zzloteria
 # Tags: internet, jogo, consulta
 # ----------------------------------------------------------------------------
 zzconfere ()

--- a/zz/zzconjugar.sh
+++ b/zz/zzconjugar.sh
@@ -15,7 +15,7 @@
 # Autor: Leslie Harlley Watter <leslie (a) watter org>
 # Desde: 2003-08-05
 # Versão: 5
-# Requisitos: zzalinhar zzcolunar zzjuntalinhas zzlblank zzminusculas zzsemacento zzsqueeze zztrim zzutf8 zzxml
+# Requisitos: zzzz zztool zzalinhar zzcolunar zzjuntalinhas zzlblank zzminusculas zzsemacento zzsqueeze zztrim zzutf8 zzxml
 # Tags: internet, consulta
 # Nota: Colaboração de José Inácio Coelho <jinacio (a) yahoo com>
 # ----------------------------------------------------------------------------

--- a/zz/zzconstantes.sh
+++ b/zz/zzconstantes.sh
@@ -18,7 +18,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-04
 # Versão: 1
-# Requisitos: zzcut zzjuntalinhas zzpad zzsqueeze zzunescape zzutf8 zzwc zzxml
+# Requisitos: zzzz zztool zzcut zzjuntalinhas zzpad zzsqueeze zzunescape zzutf8 zzwc zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzconstantes ()

--- a/zz/zzcontapalavra.sh
+++ b/zz/zzcontapalavra.sh
@@ -11,6 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-10-02
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: texto, contagem
 # ----------------------------------------------------------------------------
 zzcontapalavra ()

--- a/zz/zzcontapalavras.sh
+++ b/zz/zzcontapalavras.sh
@@ -13,7 +13,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-07
 # Versão: 1
-# Requisitos: zzminusculas
+# Requisitos: zzzz zztool zzminusculas
 # Tags: texto, contagem
 # ----------------------------------------------------------------------------
 zzcontapalavras ()

--- a/zz/zzconverte.sh
+++ b/zz/zzconverte.sh
@@ -53,7 +53,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2003-10-02
 # Versão: 6
-# Requisitos: zznumero zztestar
+# Requisitos: zzzz zztool zznumero zztestar
 # Tags: número, conversão
 # ----------------------------------------------------------------------------
 zzconverte ()

--- a/zz/zzcores.sh
+++ b/zz/zzcores.sh
@@ -7,6 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-12-11
 # Versão: 1
+# Requisitos: zzzz
 # Tags: cores, tabela
 # ----------------------------------------------------------------------------
 zzcores ()

--- a/zz/zzcorpuschristi.sh
+++ b/zz/zzcorpuschristi.sh
@@ -9,7 +9,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-11-21
 # Versão: 1
-# Requisitos: zzdata zzpascoa
+# Requisitos: zzzz zztool zzdata zzpascoa
 # Tags: data
 # ----------------------------------------------------------------------------
 zzcorpuschristi ()

--- a/zz/zzcotacao.sh
+++ b/zz/zzcotacao.sh
@@ -7,7 +7,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-19
 # Versão: 5
-# Requisitos: zzjuntalinhas zznumero zzpad zzsqueeze zztrim zzunescape zzxml
+# Requisitos: zzzz zztool zzjuntalinhas zznumero zzpad zzsqueeze zztrim zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzcotacao ()

--- a/zz/zzcpf.sh
+++ b/zz/zzcpf.sh
@@ -13,7 +13,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-12-23
 # Versão: 4
-# Requisitos: zzaleatorio zzcut
+# Requisitos: zzzz zztool zzaleatorio zzcut
 # Tags: cálculo, consulta, manipulação
 # ----------------------------------------------------------------------------
 zzcpf ()

--- a/zz/zzcut.sh
+++ b/zz/zzcut.sh
@@ -53,7 +53,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-02-09
 # Versão: 4
-# Requisitos: zzunescape
+# Requisitos: zzzz zztool zzunescape
 # Tags: cut, emulação
 # ----------------------------------------------------------------------------
 zzcut ()

--- a/zz/zzdado.sh
+++ b/zz/zzdado.sh
@@ -11,7 +11,7 @@
 # Autor: Angelito M. Goulart, www.angelitomg.com
 # Desde: 2012-12-05
 # Versão: 2
-# Requisitos: zzaleatorio
+# Requisitos: zzzz zztool zzaleatorio
 # Tags: RANDOM, emulação
 # ----------------------------------------------------------------------------
 zzdado ()

--- a/zz/zzdata.sh
+++ b/zz/zzdata.sh
@@ -25,7 +25,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-02-07
 # Versão: 5
-# Requisitos: zztestar
+# Requisitos: zzzz zztool zztestar
 # Tags: data, cálculo
 # ----------------------------------------------------------------------------
 zzdata ()

--- a/zz/zzdataestelar.sh
+++ b/zz/zzdataestelar.sh
@@ -20,7 +20,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-10-28
 # Versão: 1
-# Requisitos: zzdata zzdatafmt zznumero zzhora
+# Requisitos: zzzz zztool zzdata zzdatafmt zznumero zzhora
 # Tags: data, cálculo
 # ----------------------------------------------------------------------------
 zzdataestelar ()

--- a/zz/zzdatafmt.sh
+++ b/zz/zzdatafmt.sh
@@ -47,7 +47,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-24
 # Versão: 11
-# Requisitos: zzdata zzminusculas zznumero zzdiadasemana
+# Requisitos: zzzz zztool zzdata zzminusculas zznumero zzdiadasemana
 # Tags: data
 # ----------------------------------------------------------------------------
 zzdatafmt ()

--- a/zz/zzddd.sh
+++ b/zz/zzddd.sh
@@ -14,7 +14,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-06
 # Versão: 1
-# Requisitos: zzjuntalinhas zzminusculas zzpad zzsemacento zztrim zzxml
+# Requisitos: zzzz zztool zzjuntalinhas zzminusculas zzpad zzsemacento zztrim zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzddd ()

--- a/zz/zzdiadasemana.sh
+++ b/zz/zzdiadasemana.sh
@@ -10,7 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-24
 # Versão: 3
-# Requisitos: zzdata
+# Requisitos: zzzz zztool zzdata
 # Tags: data
 # ----------------------------------------------------------------------------
 zzdiadasemana ()

--- a/zz/zzdiasuteis.sh
+++ b/zz/zzdiasuteis.sh
@@ -10,7 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-20
 # Versão: 2
-# Requisitos: zzdata zzdiadasemana zzdatafmt zzcapitalize
+# Requisitos: zzzz zztool zzdata zzdiadasemana zzdatafmt zzcapitalize
 # Tags: data, cálculo
 # ----------------------------------------------------------------------------
 zzdiasuteis ()

--- a/zz/zzdicantonimos.sh
+++ b/zz/zzdicantonimos.sh
@@ -7,6 +7,7 @@
 # Autor: gabriell nascimento <gabriellhrn (a) gmail com>
 # Desde: 2013-04-15
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicantonimos ()

--- a/zz/zzdicasl.sh
+++ b/zz/zzdicasl.sh
@@ -10,7 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-08-08
 # Versão: 2
-# Requisitos: zzutf8
+# Requisitos: zzzz zztool zzutf8
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzdicasl ()

--- a/zz/zzdicbabylon.sh
+++ b/zz/zzdicbabylon.sh
@@ -10,6 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicbabylon ()

--- a/zz/zzdicesperanto.sh
+++ b/zz/zzdicesperanto.sh
@@ -12,7 +12,7 @@
 # Autor: Fernando Aires <fernandoaires (a) gmail com>
 # Desde: 2005-05-20
 # Versão: 5
-# Requisitos: zzurlencode
+# Requisitos: zzzz zztool zzurlencode
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicesperanto ()

--- a/zz/zzdicjargon.sh
+++ b/zz/zzdicjargon.sh
@@ -8,7 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
-# Requisitos: zztrim zzdividirtexto
+# Requisitos: zzzz zztool zztrim zzdividirtexto
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicjargon ()

--- a/zz/zzdicportugues.sh
+++ b/zz/zzdicportugues.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-02-26
 # Versão: 11
-# Requisitos: zzsemacento zzminusculas zztrim
+# Requisitos: zzzz zztool zzsemacento zzminusculas zztrim
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicportugues ()

--- a/zz/zzdicsinonimos.sh
+++ b/zz/zzdicsinonimos.sh
@@ -7,7 +7,7 @@
 # Autor: gabriell nascimento <gabriellhrn (a) gmail com>
 # Desde: 2013-04-15
 # Versão: 3
-# Requisitos: zztrim
+# Requisitos: zzzz zztool zztrim
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzdicsinonimos ()

--- a/zz/zzdiffpalavra.sh
+++ b/zz/zzdiffpalavra.sh
@@ -8,6 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-07-23
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: diff, emulação
 # ----------------------------------------------------------------------------
 zzdiffpalavra ()

--- a/zz/zzdistro.sh
+++ b/zz/zzdistro.sh
@@ -14,7 +14,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-06-15
 # Versão: 2
-# Requisitos: zzcolunar
+# Requisitos: zzzz zztool zzcolunar
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzdistro ()

--- a/zz/zzdividirtexto.sh
+++ b/zz/zzdividirtexto.sh
@@ -10,6 +10,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-04-12
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzdividirtexto ()

--- a/zz/zzdivisores.sh
+++ b/zz/zzdivisores.sh
@@ -7,6 +7,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-25
 # Versão: 6
+# Requisitos: zzzz zztool
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------
 zzdivisores ()

--- a/zz/zzdolar.sh
+++ b/zz/zzdolar.sh
@@ -7,7 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 9
-# Requisitos: zzcotacao
+# Requisitos: zzzz zzcotacao
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzdolar ()

--- a/zz/zzdominiopais.sh
+++ b/zz/zzdominiopais.sh
@@ -9,6 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-15
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzdominiopais ()

--- a/zz/zzdos2unix.sh
+++ b/zz/zzdos2unix.sh
@@ -8,6 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: arquivo, conversão
 # ----------------------------------------------------------------------------
 zzdos2unix ()

--- a/zz/zzecho.sh
+++ b/zz/zzecho.sh
@@ -16,6 +16,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-09-02
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: echo, emulação
 # ----------------------------------------------------------------------------
 zzecho ()

--- a/zz/zzencoding.sh
+++ b/zz/zzencoding.sh
@@ -10,6 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2015-03-21
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzencoding ()

--- a/zz/zzenglish.sh
+++ b/zz/zzenglish.sh
@@ -7,7 +7,7 @@
 # Autor: Luciano ES
 # Desde: 2008-09-07
 # Versão: 7
-# Requisitos: zztrim zzutf8 zzsqueeze
+# Requisitos: zzzz zztool zztrim zzutf8 zzsqueeze
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzenglish ()

--- a/zz/zzestado.sh
+++ b/zz/zzestado.sh
@@ -27,7 +27,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-21
 # Versão: 5
-# Requisitos: zzpad
+# Requisitos: zzzz zzpad
 # Tags: utilitário
 # ----------------------------------------------------------------------------
 zzestado ()

--- a/zz/zzexcuse.sh
+++ b/zz/zzexcuse.sh
@@ -7,7 +7,7 @@
 # Autor: Italo Gonçales, @goncalesi, <italo.goncales (a) gmail com>
 # Desde: 2015-09-26
 # Versão: 2
-# Requisitos: zztrim
+# Requisitos: zzzz zztool zztrim
 # Tags: internet, diversão
 # ----------------------------------------------------------------------------
 zzexcuse ()

--- a/zz/zzextensao.sh
+++ b/zz/zzextensao.sh
@@ -8,6 +8,7 @@
 # Autor: Lauro Cavalcanti de Sa <lauro (a) ecdesa com>
 # Desde: 2009-09-21
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzextensao ()

--- a/zz/zzf1.sh
+++ b/zz/zzf1.sh
@@ -19,7 +19,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2020-12-26
 # Versão: 1
-# Requisitos: zzpad zztrim zzxml
+# Requisitos: zzzz zztool zzpad zztrim zzxml
 # Tags: internet, corrida, consulta
 # ----------------------------------------------------------------------------
 zzf1 ()

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -14,7 +14,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-14
 # Versão: 4
-# Requisitos: zzjuntalinhas zzdivisores
+# Requisitos: zzzz zztool zzjuntalinhas zzdivisores
 # Tags: número, cálculo
 # Nota: opcional factor
 # ----------------------------------------------------------------------------

--- a/zz/zzfeed.sh
+++ b/zz/zzfeed.sh
@@ -19,7 +19,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-03
 # Versão: 11
-# Requisitos: zzxml zzunescape zztrim zzutf8
+# Requisitos: zzzz zztool zzxml zzunescape zztrim zzutf8
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzfeed ()

--- a/zz/zzferiado.sh
+++ b/zz/zzferiado.sh
@@ -11,7 +11,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-11-21
 # Versão: 6
-# Requisitos: zzcarnaval zzcorpuschristi zzdiadasemana zzsextapaixao zzsemacento
+# Requisitos: zzzz zztool zzcarnaval zzcorpuschristi zzdiadasemana zzsextapaixao zzsemacento
 # Tags: data
 # ----------------------------------------------------------------------------
 zzferiado ()

--- a/zz/zzfilme.sh
+++ b/zz/zzfilme.sh
@@ -8,7 +8,7 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2018-04-16
 # Versão: 1
-# Requisitos: zzxml zztrim zzecho zzcapitalize zzurldecode zzurlencode
+# Requisitos: zzzz zztool zzxml zztrim zzecho zzcapitalize zzurldecode zzurlencode
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzfilme ()

--- a/zz/zzfoneletra.sh
+++ b/zz/zzfoneletra.sh
@@ -7,7 +7,7 @@
 # Autor: Rodolfo de Faria <rodolfo faria (a) fujifilm com br>
 # Desde: 2006-10-17
 # Versão: 1
-# Requisitos: zzmaiusculas
+# Requisitos: zzzz zztool zzmaiusculas
 # Tags: texto, número, conversão
 # ----------------------------------------------------------------------------
 zzfoneletra ()

--- a/zz/zzfrenteverso2pdf.sh
+++ b/zz/zzfrenteverso2pdf.sh
@@ -13,6 +13,7 @@
 # Autor: Lauro Cavalcanti de Sa <laurocdesa (a) gmail com>
 # Desde: 2009-09-17
 # Versão: 4
+# Requisitos: zzzz zztool
 # Tags: arquivo, manipulação
 # Nota: requer pdftk
 # ----------------------------------------------------------------------------

--- a/zz/zzfutebol.sh
+++ b/zz/zzfutebol.sh
@@ -27,7 +27,7 @@
 # Autor: Jefferson Fausto Vaz (www.faustovaz.com)
 # Desde: 2014-04-08
 # Versão: 11
-# Requisitos: zzdatafmt zzjuntalinhas zzpad zzsqueeze zztrim zzutf8 zzxml
+# Requisitos: zzzz zztool zzdatafmt zzjuntalinhas zzpad zzsqueeze zztrim zzutf8 zzxml
 # Tags: internet, futebol, consulta
 # ----------------------------------------------------------------------------
 zzfutebol ()

--- a/zz/zzgeoip.sh
+++ b/zz/zzgeoip.sh
@@ -7,7 +7,7 @@
 # Autor: Alexandre Magno <alexandre.mbm (a) gmail com>
 # Desde: 2013-07-06
 # Versão: 3
-# Requisitos: zzxml zzipinternet zzecho zzminiurl zztestar
+# Requisitos: zzzz zztool zzxml zzipinternet zzecho zzminiurl zztestar
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzgeoip ()

--- a/zz/zzglobo.sh
+++ b/zz/zzglobo.sh
@@ -6,7 +6,7 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2017-11-29
 # Versão: 9
-# Requisitos: zztv
+# Requisitos: zzzz zztv
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzglobo ()

--- a/zz/zzgravatar.sh
+++ b/zz/zzgravatar.sh
@@ -22,7 +22,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-06
 # Versão: 1
-# Requisitos: zzmd5 zzminusculas zztrim
+# Requisitos: zzzz zztool zzmd5 zzminusculas zztrim
 # Tags: internet, url
 # ----------------------------------------------------------------------------
 zzgravatar ()

--- a/zz/zzhexa2str.sh
+++ b/zz/zzhexa2str.sh
@@ -8,6 +8,7 @@
 # Autor: Fernando Mercês <fernando (a) mentebinaria.com.br>
 # Desde: 2012-02-24
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzhexa2str ()

--- a/zz/zzhora.sh
+++ b/zz/zzhora.sh
@@ -15,6 +15,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 5
+# Requisitos: zzzz zztool
 # Tags: tempo, cálculo
 # ----------------------------------------------------------------------------
 zzhora ()

--- a/zz/zzhoracerta.sh
+++ b/zz/zzhoracerta.sh
@@ -13,7 +13,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-03-29
 # Versão: 5
-# Requisitos: zzjuntalinhas zztrim zzxml
+# Requisitos: zzzz zztool zzjuntalinhas zztrim zzxml
 # Tags: internet, tempo, consulta
 # ----------------------------------------------------------------------------
 zzhoracerta ()

--- a/zz/zzhoramin.sh
+++ b/zz/zzhoramin.sh
@@ -9,7 +9,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-12-05
 # Versão: 4
-# Requisitos: zzhora zztestar
+# Requisitos: zzzz zzhora zztestar
 # Tags: tempo, conversão
 # ----------------------------------------------------------------------------
 zzhoramin ()

--- a/zz/zzhorariodeverao.sh
+++ b/zz/zzhorariodeverao.sh
@@ -9,7 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-24
 # Versão: 1
-# Requisitos: zzcarnaval zzdata zzdiadasemana
+# Requisitos: zzzz zztool zzcarnaval zzdata zzdiadasemana
 # Tags: data
 # ----------------------------------------------------------------------------
 zzhorariodeverao ()

--- a/zz/zzhoroscopo.sh
+++ b/zz/zzhoroscopo.sh
@@ -12,7 +12,7 @@
 # Autor: Juliano Fernandes, http://julianofernandes.com.br
 # Desde: 2016-05-07
 # Versão: 1
-# Requisitos: zzsemacento zzminusculas zztrim zzxml
+# Requisitos: zzzz zztool zzsemacento zzminusculas zztrim zzxml
 # Tags: internet, distração, consulta
 # ----------------------------------------------------------------------------
 zzhoroscopo ()

--- a/zz/zzhowto.sh
+++ b/zz/zzhowto.sh
@@ -8,7 +8,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-08-27
 # Versão: 3
-# Requisitos: zztrim zzxml
+# Requisitos: zzzz zztool zztrim zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzhowto ()

--- a/zz/zzhsort.sh
+++ b/zz/zzhsort.sh
@@ -23,7 +23,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-10-07
 # Versão: 2
-# Requisitos: zztranspor
+# Requisitos: zzzz zztool zztranspor
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzhsort ()

--- a/zz/zzimc.sh
+++ b/zz/zzimc.sh
@@ -7,7 +7,7 @@
 # Autor: Rafael Araújo <rafaelaraujosilva (a) gmail com>
 # Desde: 2015-10-30
 # Versão: 1
-# Requisitos: zztestar
+# Requisitos: zzzz zztool zztestar
 # Tags: cálculo
 # ----------------------------------------------------------------------------
 zzimc ()

--- a/zz/zziostat.sh
+++ b/zz/zziostat.sh
@@ -26,6 +26,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2015-02-17
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: sistema, consulta
 # Nota: requer iostat
 # ----------------------------------------------------------------------------

--- a/zz/zzipinternet.sh
+++ b/zz/zzipinternet.sh
@@ -6,6 +6,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2005-09-01
 # Versão: 6
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzipinternet ()

--- a/zz/zzipv6.sh
+++ b/zz/zzipv6.sh
@@ -11,7 +11,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2021-01-13
 # Versão: 1
-# Requisitos: zzjuntalinhas zztestar zzxml
+# Requisitos: zzzz zztool zzjuntalinhas zztestar zzxml
 # Tags: internet, ip
 # ----------------------------------------------------------------------------
 zzipv6 ()

--- a/zz/zzit.sh
+++ b/zz/zzit.sh
@@ -23,7 +23,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-02-28
 # Versão: 5
-# Requisitos: zzsemacento zzutf8 zzxml zzsqueeze zzdatafmt zzlinha
+# Requisitos: zzzz zztool zzsemacento zzutf8 zzxml zzsqueeze zzdatafmt zzlinha
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzit ()

--- a/zz/zzjoin.sh
+++ b/zz/zzjoin.sh
@@ -18,6 +18,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-12-05
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzjoin ()

--- a/zz/zzjquery.sh
+++ b/zz/zzjquery.sh
@@ -15,7 +15,7 @@
 # Autor: Felipe Nascimento Silva Pena <felipensp (a) gmail com>
 # Desde: 2007-12-04
 # Versão: 5
-# Requisitos: zzcapitalize zzlimpalixo zzunescape zzxml
+# Requisitos: zzzz zztool zzcapitalize zzlimpalixo zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzjquery ()

--- a/zz/zzjuntalinhas.sh
+++ b/zz/zzjuntalinhas.sh
@@ -21,7 +21,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-02
 # Versão: 3
-# Requisitos: zzdos2unix
+# Requisitos: zzzz zztool zzdos2unix
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzjuntalinhas ()

--- a/zz/zzlblank.sh
+++ b/zz/zzlblank.sh
@@ -16,6 +16,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-05-11
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzlblank ()

--- a/zz/zzlembrete.sh
+++ b/zz/zzlembrete.sh
@@ -9,6 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-22
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: arquivo, utilitário
 # ----------------------------------------------------------------------------
 zzlembrete ()

--- a/zz/zzlibertadores.sh
+++ b/zz/zzlibertadores.sh
@@ -14,7 +14,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-17
 # Versão: 16
-# Requisitos: zzdatafmt zzjuntalinhas zzlimpalixo zzunescape zzxml
+# Requisitos: zzzz zztool zzdatafmt zzjuntalinhas zzlimpalixo zzunescape zzxml
 # Tags: internet, futebol, consulta
 # ----------------------------------------------------------------------------
 zzlibertadores ()

--- a/zz/zzlimpalixo.sh
+++ b/zz/zzlimpalixo.sh
@@ -12,7 +12,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-04-24
 # Versão: 3
-# Requisitos: zzjuntalinhas
+# Requisitos: zzzz zztool zzjuntalinhas
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzlimpalixo ()

--- a/zz/zzlinha.sh
+++ b/zz/zzlinha.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-12-23
 # Versão: 2
-# Requisitos: zzaleatorio zztestar
+# Requisitos: zzzz zztool zzaleatorio zztestar
 # Tags: arquivo, RANDOM, sed, emulação
 # ----------------------------------------------------------------------------
 zzlinha ()

--- a/zz/zzlinux.sh
+++ b/zz/zzlinux.sh
@@ -7,6 +7,7 @@
 # Autor: Diogo Gullit <guuuuuuuuuullit (a) yahoo com br>
 # Desde: 2008-05-01
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzlinux ()

--- a/zz/zzlinuxnews.sh
+++ b/zz/zzlinuxnews.sh
@@ -15,7 +15,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-11-07
 # Versão: 7
-# Requisitos: zzfeed
+# Requisitos: zzzz zztool zzfeed
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzlinuxnews ()

--- a/zz/zzlocale.sh
+++ b/zz/zzlocale.sh
@@ -8,6 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2005-06-30
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzlocale ()

--- a/zz/zzlorem.sh
+++ b/zz/zzlorem.sh
@@ -8,6 +8,7 @@
 # Autor: Angelito M. Goulart, www.angelitomg.com
 # Desde: 2012-12-11
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: texto, teste
 # ----------------------------------------------------------------------------
 zzlorem ()

--- a/zz/zzloteria.sh
+++ b/zz/zzloteria.sh
@@ -16,7 +16,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-05-18
 # Versão: 17
-# Requisitos: zzdatafmt zzjuntalinhas zzhoramin zzsqueeze zzunescape zzxml
+# Requisitos: zzzz zztool zzdatafmt zzjuntalinhas zzhoramin zzsqueeze zzunescape zzxml
 # Tags: internet, jogo, consulta
 # Nota: requer unzip
 # ----------------------------------------------------------------------------

--- a/zz/zzlua.sh
+++ b/zz/zzlua.sh
@@ -13,6 +13,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-09
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzlua ()

--- a/zz/zzmacaddress.sh
+++ b/zz/zzmacaddress.sh
@@ -6,6 +6,7 @@
 # Autor: Adriano Laureano, @sl4ureano
 # Desde: 2018-10-09
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: sistema, consulta
 # Nota: (ou) ip ifconfig
 # ----------------------------------------------------------------------------

--- a/zz/zzmacvendor.sh
+++ b/zz/zzmacvendor.sh
@@ -8,7 +8,7 @@
 # Autor: Rafael S. Guimaraes, www.rafaelguimaraes.net
 # Desde: 2016-02-03
 # Versão: 3
-# Requisitos: zztestar zzcut zzdominiopais
+# Requisitos: zzzz zztool zztestar zzcut zzdominiopais
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzmacvendor ()

--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-08-28
 # Versão: 1
-# Requisitos: zztrim
+# Requisitos: zzzz zztrim
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzmaiores ()

--- a/zz/zzmaiusculas.sh
+++ b/zz/zzmaiusculas.sh
@@ -7,6 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-06-12
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzmaiusculas ()

--- a/zz/zzmariadb.sh
+++ b/zz/zzmariadb.sh
@@ -11,7 +11,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-07-03
 # Versão: 4
-# Requisitos: zzminusculas zzsemacento zztrim
+# Requisitos: zzzz zztool zzminusculas zzsemacento zztrim
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzmariadb ()

--- a/zz/zzmat.sh
+++ b/zz/zzmat.sh
@@ -36,7 +36,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2011-01-19
 # Versão: 23
-# Requisitos: zzcalcula zzseq zzaleatorio zztrim zzconverte zztestar
+# Requisitos: zzzz zztool zzcalcula zzseq zzaleatorio zztrim zzconverte zztestar
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------
 zzmat ()

--- a/zz/zzmcd.sh
+++ b/zz/zzmcd.sh
@@ -11,6 +11,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-03-30
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: diretório, emulação
 # ----------------------------------------------------------------------------
 zzmcd ()

--- a/zz/zzmd5.sh
+++ b/zz/zzmd5.sh
@@ -9,6 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-06
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: hash, cálculo, emulação
 # Nota: (ou) md5 md5sum
 # ----------------------------------------------------------------------------

--- a/zz/zzminiurl.sh
+++ b/zz/zzminiurl.sh
@@ -10,6 +10,7 @@
 # Autor: Vinícius Venâncio Leite <vv.leite (a) gmail com>
 # Desde: 2010-04-26
 # Versão: 7
+# Requisitos: zzzz zztool
 # Tags: internet, url
 # ----------------------------------------------------------------------------
 zzminiurl ()

--- a/zz/zzminusculas.sh
+++ b/zz/zzminusculas.sh
@@ -7,6 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-06-12
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzminusculas ()

--- a/zz/zzmix.sh
+++ b/zz/zzmix.sh
@@ -24,6 +24,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-11-01
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzmix ()

--- a/zz/zzmoneylog.sh
+++ b/zz/zzmoneylog.sh
@@ -20,7 +20,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-25
 # Versão: 1
-# Requisitos: zzcalcula zzdatafmt zzdos2unix
+# Requisitos: zzzz zztool zzcalcula zzdatafmt zzdos2unix
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzmoneylog ()

--- a/zz/zzmudaprefixo.sh
+++ b/zz/zzmudaprefixo.sh
@@ -10,6 +10,7 @@
 # Autor: Lauro Cavalcanti de Sa <lauro (a) ecdesa com>
 # Desde: 2009-09-21
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzmudaprefixo ()

--- a/zz/zznatal.sh
+++ b/zz/zznatal.sh
@@ -8,7 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-12-23
 # Versão: 1
-# Requisitos: zzlinha
+# Requisitos: zzzz zztool zzlinha
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zznatal ()

--- a/zz/zznerdcast.sh
+++ b/zz/zznerdcast.sh
@@ -24,7 +24,7 @@
 # Autor: Diogo Alexsander Cavilha <diogocavilha (a) gmail com>
 # Desde: 2016-09-19
 # Versão: 2
-# Requisitos: zzdatafmt zzunescape zzxml
+# Requisitos: zzzz zztool zzdatafmt zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zznerdcast ()

--- a/zz/zznome.sh
+++ b/zz/zznome.sh
@@ -12,7 +12,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2011-04-22
 # Versão: 5
-# Requisitos: zzsemacento zzminusculas zztrim zzutf8 zzxml
+# Requisitos: zzzz zztool zzsemacento zzminusculas zztrim zzutf8 zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zznome ()

--- a/zz/zznomealeatorio.sh
+++ b/zz/zznomealeatorio.sh
@@ -8,7 +8,7 @@
 # Autor: Guilherme Magalhães Gall <gmgall (a) gmail com>
 # Desde: 2013-03-03
 # Versão: 2
-# Requisitos: zzseq zzaleatorio
+# Requisitos: zzzz zztool zzseq zzaleatorio
 # Tags: sugestão
 # ----------------------------------------------------------------------------
 zznomealeatorio ()

--- a/zz/zznomefoto.sh
+++ b/zz/zznomefoto.sh
@@ -15,7 +15,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2004-11-10
 # Versão: 3
-# Requisitos: zzminusculas
+# Requisitos: zzzz zztool zzminusculas
 # Tags: arquivo, manipulação
 # Nota: (ou) exiftool exiftime identify
 # ----------------------------------------------------------------------------

--- a/zz/zznoticiaslinux.sh
+++ b/zz/zznoticiaslinux.sh
@@ -14,7 +14,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-12-17
 # Versão: 11
-# Requisitos: zzfeed
+# Requisitos: zzzz zztool zzfeed
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zznoticiaslinux ()

--- a/zz/zznoticiassec.sh
+++ b/zz/zznoticiassec.sh
@@ -13,7 +13,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2003-07-13
 # Versão: 4
-# Requisitos: zzfeed
+# Requisitos: zzzz zztool zzfeed
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zznoticiassec ()

--- a/zz/zznumero.sh
+++ b/zz/zznumero.sh
@@ -31,7 +31,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-05
 # Versão: 13
-# Requisitos: zzvira zztestar
+# Requisitos: zzzz zztool zzvira zztestar
 # Tags: número, manipulação
 # ----------------------------------------------------------------------------
 zznumero ()

--- a/zz/zzora.sh
+++ b/zz/zzora.sh
@@ -7,7 +7,7 @@
 # Autor: Rodrigo Pereira da Cunha <rodrigopc (a) gmail.com>
 # Desde: 2005-11-03
 # Versão: 6
-# Requisitos: zzurldecode
+# Requisitos: zzzz zztool zzurldecode
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzora ()

--- a/zz/zzpad.sh
+++ b/zz/zzpad.sh
@@ -17,6 +17,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-05-18
 # Versão: 5
+# Requisitos: zzzz zztool
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzpad ()

--- a/zz/zzpais.sh
+++ b/zz/zzpais.sh
@@ -16,7 +16,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-29
 # Versão: 4
-# Requisitos: zzlinha zzpad
+# Requisitos: zzzz zztool zzlinha zzpad
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzpais ()

--- a/zz/zzpalpite.sh
+++ b/zz/zzpalpite.sh
@@ -11,7 +11,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2012-06-03
 # Versão: 6
-# Requisitos: zzaleatorio zzminusculas zzsemacento zzseq
+# Requisitos: zzzz zztool zzaleatorio zzminusculas zzsemacento zzseq
 # Tags: jogo, distração
 # ----------------------------------------------------------------------------
 zzpalpite ()

--- a/zz/zzpascoa.sh
+++ b/zz/zzpascoa.sh
@@ -9,6 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-10-23
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: data
 # ----------------------------------------------------------------------------
 zzpascoa ()

--- a/zz/zzpgsql.sh
+++ b/zz/zzpgsql.sh
@@ -11,7 +11,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-05-11
 # Versão: 4
-# Requisitos: zzjuntalinhas zzsqueeze zztrim zzxml
+# Requisitos: zzzz zztool zzjuntalinhas zzsqueeze zztrim zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzpgsql ()

--- a/zz/zzphp.sh
+++ b/zz/zzphp.sh
@@ -13,7 +13,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-06
 # Versão: 3
-# Requisitos: zzunescape
+# Requisitos: zzzz zztool zzunescape
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzphp ()

--- a/zz/zzplay.sh
+++ b/zz/zzplay.sh
@@ -16,7 +16,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-13
 # Versão: 6
-# Requisitos: zzextensao zzminusculas zzunescape zzxml
+# Requisitos: zzzz zztool zzextensao zzminusculas zzunescape zzxml
 # Tags: aúdio
 # Nota: (ou) afplay play mplayer cvlc avplay ffplay mpg321 mpg123 ogg123
 # ----------------------------------------------------------------------------

--- a/zz/zzporcento.sh
+++ b/zz/zzporcento.sh
@@ -18,7 +18,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-12-11
 # Versão: 6
-# Requisitos: zztestar
+# Requisitos: zzzz zztool zztestar
 # Tags: número, cálculo
 # ----------------------------------------------------------------------------
 zzporcento ()

--- a/zz/zzporta.sh
+++ b/zz/zzporta.sh
@@ -10,7 +10,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-11-15
 # Versão: 2
-# Requisitos: zzjuntalinhas
+# Requisitos: zzzz zztool zzjuntalinhas
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzporta ()

--- a/zz/zzpronuncia.sh
+++ b/zz/zzpronuncia.sh
@@ -6,7 +6,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-04-10
 # Versão: 5
-# Requisitos: zzplay zzunescape
+# Requisitos: zzzz zztool zzplay zzunescape
 # Tags: internet, aúdio
 # Nota: opcional say
 # ----------------------------------------------------------------------------

--- a/zz/zzquimica.sh
+++ b/zz/zzquimica.sh
@@ -10,7 +10,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-22
 # Versão: 7
-# Requisitos: zzcapitalize zzwikipedia zzxml zzpad
+# Requisitos: zzzz zztool zzcapitalize zzwikipedia zzxml zzpad
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzquimica ()

--- a/zz/zzramones.sh
+++ b/zz/zzramones.sh
@@ -9,7 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-07-24
 # Versão: 1
-# Requisitos: zzlinha
+# Requisitos: zzzz zztool zzlinha
 # Tags: internet, música, distração
 # ----------------------------------------------------------------------------
 zzramones ()

--- a/zz/zzrastreamento.sh
+++ b/zz/zzrastreamento.sh
@@ -8,7 +8,7 @@
 # Autor: Frederico Freire Boaventura <anonymous (a) galahad com br>
 # Desde: 2007-06-25
 # Versão: 4
-# Requisitos: zztrim zzunescape zzxml zzjuntalinhas
+# Requisitos: zzzz zztool zztrim zzunescape zzxml zzjuntalinhas
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzrastreamento ()

--- a/zz/zzrepete.sh
+++ b/zz/zzrepete.sh
@@ -8,7 +8,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-04-12
 # Versão: 1
-# Requisitos: zzseq
+# Requisitos: zzzz zztool zzseq
 # Tags: texto, manipulação
 # ----------------------------------------------------------------------------
 zzrepete ()

--- a/zz/zzromanos.sh
+++ b/zz/zzromanos.sh
@@ -10,7 +10,7 @@
 # Autor: Guilherme Magalhães Gall <gmgall (a) gmail com>
 # Desde: 2011-07-19
 # Versão: 4
-# Requisitos: zzmaiusculas zztac
+# Requisitos: zzzz zztool zzmaiusculas zztac
 # Tags: número, conversão
 # ----------------------------------------------------------------------------
 zzromanos ()

--- a/zz/zzrot13.sh
+++ b/zz/zzrot13.sh
@@ -8,6 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-07-23
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzrot13 ()

--- a/zz/zzrot47.sh
+++ b/zz/zzrot47.sh
@@ -8,6 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-07-23
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzrot47 ()

--- a/zz/zzrpmfind.sh
+++ b/zz/zzrpmfind.sh
@@ -9,6 +9,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-02-22
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzrpmfind ()

--- a/zz/zzsecurity.sh
+++ b/zz/zzsecurity.sh
@@ -11,7 +11,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-12-23
 # Versão: 13
-# Requisitos: zzminusculas zzfeed zztac
+# Requisitos: zzzz zztool zzminusculas zzfeed zztac
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzsecurity ()

--- a/zz/zzsemacento.sh
+++ b/zz/zzsemacento.sh
@@ -7,6 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2010-05-24
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzsemacento ()

--- a/zz/zzsenha.sh
+++ b/zz/zzsenha.sh
@@ -16,7 +16,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-11-07
 # Versão: 4
-# Requisitos: zzaleatorio
+# Requisitos: zzzz zztool zzaleatorio
 # Tags: sugestão
 # ----------------------------------------------------------------------------
 zzsenha ()

--- a/zz/zzseq.sh
+++ b/zz/zzseq.sh
@@ -17,7 +17,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-12-06
 # Versão: 1
-# Requisitos: zztestar
+# Requisitos: zzzz zztool zztestar
 # Tags: seq, emulação
 # ----------------------------------------------------------------------------
 zzseq ()

--- a/zz/zzsextapaixao.sh
+++ b/zz/zzsextapaixao.sh
@@ -9,7 +9,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-11-21
 # Versão: 1
-# Requisitos: zzdata zzpascoa
+# Requisitos: zzzz zztool zzdata zzpascoa
 # Tags: data
 # ----------------------------------------------------------------------------
 zzsextapaixao ()

--- a/zz/zzsheldon.sh
+++ b/zz/zzsheldon.sh
@@ -7,7 +7,7 @@
 # Autor: Jonas Gentina, <jgentina (a) gmail com>
 # Desde: 2015-09-25
 # Versão: 2
-# Requisitos: zzaleatorio zztrim zzjuntalinhas zzlinha zzsqueeze zzxml zzutf8
+# Requisitos: zzzz zztool zzaleatorio zztrim zzjuntalinhas zzlinha zzsqueeze zzxml zzutf8
 # Tags: internet, distação
 # ----------------------------------------------------------------------------
 zzsheldon ()

--- a/zz/zzshuffle.sh
+++ b/zz/zzshuffle.sh
@@ -7,7 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-06-19
 # Versão: 1
-# Requisitos: zzaleatorio
+# Requisitos: zzzz zztool zzaleatorio
 # Tags: shuffle, emulação
 # ----------------------------------------------------------------------------
 zzshuffle ()

--- a/zz/zzsigla.sh
+++ b/zz/zzsigla.sh
@@ -8,7 +8,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2002-02-21
 # Versão: 3
-# Requisitos: zztrim
+# Requisitos: zzzz zztool zztrim
 # Tags: internet, dicionário
 # ----------------------------------------------------------------------------
 zzsigla ()

--- a/zz/zzsplit.sh
+++ b/zz/zzsplit.sh
@@ -23,6 +23,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-11-10
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zzsplit ()

--- a/zz/zzsqueeze.sh
+++ b/zz/zzsqueeze.sh
@@ -17,6 +17,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-09-24
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: squeeze, emulação
 # ----------------------------------------------------------------------------
 zzsqueeze ()

--- a/zz/zzss.sh
+++ b/zz/zzss.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2003-06-12
 # Versão: 1
-# Requisitos: zzaleatorio zztrim
+# Requisitos: zzzz zztool zzaleatorio zztrim
 # Tags: screen saver, emulação
 # ----------------------------------------------------------------------------
 zzss ()

--- a/zz/zzstr2hexa.sh
+++ b/zz/zzstr2hexa.sh
@@ -8,7 +8,7 @@
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2012-03-30
 # Versão: 9
-# Requisitos: zztrim
+# Requisitos: zzzz zztool zztrim
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzstr2hexa ()

--- a/zz/zzsubway.sh
+++ b/zz/zzsubway.sh
@@ -7,7 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2008-12-02
 # Versão: 1
-# Requisitos: zzshuffle zzaleatorio
+# Requisitos: zzzz zztool zzshuffle zzaleatorio
 # Tags: sugestão
 # ----------------------------------------------------------------------------
 zzsubway ()

--- a/zz/zztabuada.sh
+++ b/zz/zztabuada.sh
@@ -18,7 +18,7 @@
 # Autor: Kl0nEz <kl0nez (a) wifi org br>
 # Desde: 2011-08-23
 # Versão: 6
-# Requisitos: zzseq zztestar
+# Requisitos: zzzz zztool zzseq zztestar
 # Tags: número, tabela
 # ----------------------------------------------------------------------------
 zztabuada ()

--- a/zz/zztac.sh
+++ b/zz/zztac.sh
@@ -10,6 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2013-02-24
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: tac, emulação
 # ----------------------------------------------------------------------------
 zztac ()

--- a/zz/zztempo.sh
+++ b/zz/zztempo.sh
@@ -47,6 +47,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-02-19
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zztempo ()

--- a/zz/zztestar.sh
+++ b/zz/zztestar.sh
@@ -34,6 +34,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-03-14
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: número, teste
 # ----------------------------------------------------------------------------
 zztestar ()

--- a/zz/zztimer.sh
+++ b/zz/zztimer.sh
@@ -27,7 +27,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-01-25
 # Versão: 5
-# Requisitos: zzcut
+# Requisitos: zzzz zztool zzcut
 # Tags: tempo
 # ----------------------------------------------------------------------------
 zztimer ()

--- a/zz/zztop.sh
+++ b/zz/zztop.sh
@@ -29,7 +29,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2015-07-19
 # Versão: 4
-# Requisitos: zzcolunar zzjuntalinhas zzsqueeze zztac zztrim zzunescape zzxml
+# Requisitos: zzzz zztool zzcolunar zzjuntalinhas zzsqueeze zztac zztrim zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zztop ()

--- a/zz/zztranspor.sh
+++ b/zz/zztranspor.sh
@@ -21,7 +21,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-09-03
 # Versão: 1
-# Requisitos: zztrim
+# Requisitos: zzzz zztool zztrim
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zztranspor ()

--- a/zz/zztrim.sh
+++ b/zz/zztrim.sh
@@ -19,6 +19,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2015-03-05
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: trim, emulação
 # ----------------------------------------------------------------------------
 zztrim ()

--- a/zz/zztrocaarquivos.sh
+++ b/zz/zztrocaarquivos.sh
@@ -6,6 +6,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-06-12
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zztrocaarquivos ()

--- a/zz/zztrocaextensao.sh
+++ b/zz/zztrocaextensao.sh
@@ -7,6 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-15
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: arquivo, manipulação
 # ----------------------------------------------------------------------------
 zztrocaextensao ()

--- a/zz/zztrocapalavra.sh
+++ b/zz/zztrocapalavra.sh
@@ -7,6 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-04
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zztrocapalavra ()

--- a/zz/zztv.sh
+++ b/zz/zztv.sh
@@ -23,7 +23,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-02-19
 # Versão: 14
-# Requisitos: zzcolunar zzdatafmt zzjuntalinhas zzpad zzsqueeze zztrim zzunescape zzxml
+# Requisitos: zzzz zztool zzcolunar zzdatafmt zzjuntalinhas zzpad zzsqueeze zztrim zzunescape zzxml
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zztv ()

--- a/zz/zzunescape.sh
+++ b/zz/zzunescape.sh
@@ -13,6 +13,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-03
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzunescape ()

--- a/zz/zzunicode.sh
+++ b/zz/zzunicode.sh
@@ -12,7 +12,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-10-13
 # Versão: 2
-# Requisitos: zzcolunar zzlimpalixo zztrim zzunescape
+# Requisitos: zzzz zztool zzcolunar zzlimpalixo zztrim zzunescape
 # Tags: internet, texto, tabela
 # ----------------------------------------------------------------------------
 zzunicode ()

--- a/zz/zzunicode2ascii.sh
+++ b/zz/zzunicode2ascii.sh
@@ -8,6 +8,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-06
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzunicode2ascii ()

--- a/zz/zzuniq.sh
+++ b/zz/zzuniq.sh
@@ -9,6 +9,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-06-22
 # Versão: 3
+# Requisitos: zzzz zztool
 # Tags: uniq, emulação
 # ----------------------------------------------------------------------------
 zzuniq ()

--- a/zz/zzunix2dos.sh
+++ b/zz/zzunix2dos.sh
@@ -7,6 +7,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-02-22
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzunix2dos ()

--- a/zz/zzurldecode.sh
+++ b/zz/zzurldecode.sh
@@ -9,6 +9,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2014-03-14
 # Versão: 2
+# Requisitos: zzzz zztool
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzurldecode ()

--- a/zz/zzurlencode.sh
+++ b/zz/zzurlencode.sh
@@ -16,7 +16,7 @@
 # Autor: Guilherme Magalhães Gall <gmgall (a) gmail com>
 # Desde: 2013-03-19
 # Versão: 4
-# Requisitos: zzmaiusculas
+# Requisitos: zzzz zztool zzmaiusculas
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzurlencode ()

--- a/zz/zzutf8.sh
+++ b/zz/zzutf8.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2015-03-21
 # Versão: 2
-# Requisitos: zzencoding
+# Requisitos: zzzz zztool zzencoding
 # Tags: texto, conversão
 # ----------------------------------------------------------------------------
 zzutf8 ()

--- a/zz/zzvdp.sh
+++ b/zz/zzvdp.sh
@@ -13,7 +13,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2013-03-25
 # Versão: 7
-# Requisitos: zzunescape zzxml
+# Requisitos: zzzz zztool zzunescape zzxml
 # Tags: internet, distração
 # ----------------------------------------------------------------------------
 zzvdp ()

--- a/zz/zzvds.sh
+++ b/zz/zzvds.sh
@@ -13,7 +13,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2018-05-07
 # Versão: 1
-# Requisitos: zzjuntalinhas zztrim zzunescape zzxml
+# Requisitos: zzzz zztool zzjuntalinhas zztrim zzunescape zzxml
 # Tags: internet, distração
 # ----------------------------------------------------------------------------
 zzvds ()

--- a/zz/zzvira.sh
+++ b/zz/zzvira.sh
@@ -10,7 +10,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2010-05-24
 # Versão: 3
-# Requisitos: zzsemacento zzminusculas
+# Requisitos: zzzz zztool zzsemacento zzminusculas
 # Tags: rev, emulação
 # ----------------------------------------------------------------------------
 zzvira ()

--- a/zz/zzwc.sh
+++ b/zz/zzwc.sh
@@ -26,6 +26,7 @@
 # Autor: Itamar <itamarnet (a) yahoo com br>
 # Desde: 2016-03-10
 # Versão: 1
+# Requisitos: zzzz zztool
 # Tags: contagem, emulação
 # ----------------------------------------------------------------------------
 zzwc ()

--- a/zz/zzwikipedia.sh
+++ b/zz/zzwikipedia.sh
@@ -14,6 +14,7 @@
 # Autor: Thobias Salazar Trevisan, www.thobias.org
 # Desde: 2004-10-28
 # Versão: 4
+# Requisitos: zzzz zztool
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzwikipedia ()

--- a/zz/zzxml.sh
+++ b/zz/zzxml.sh
@@ -27,7 +27,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2011-05-03
 # Versão: 15
-# Requisitos: zzjuntalinhas zzuniq zzunescape
+# Requisitos: zzzz zztool zzjuntalinhas zzuniq zzunescape
 # Tags: parser
 # ----------------------------------------------------------------------------
 zzxml ()


### PR DESCRIPTION
Se uma função ZZ é necessária para o funcionamento de outra, ela deve
ser listada como um requisito.

Até então as funções-base ($ZZBASE) tinham um tratamento especial,
sendo requisitos implícitos. Agora todos os requisitos são explícitos.

Isso torna as dependências mais claras, e prepara terreno para no
futuro eventualmente deixar de existir o conceito de funções-base.

O comando usado para inserir `zzzz` e `zztool` como requisitos em
todas as funções foi:

    for f in *.sh; do gsed -i 's/^# Requisitos:/& zzzz zztool/' $f; done

Depois rodei o `util/requisitos.sh` e arrumei o que ele reclamou:

1 - Algumas funções ainda não possuíam o campo Requisitos:

    cat zz/req | cut -d: -f 1 | while read file
    do
        gsed -i '/^# Versão:/ a# Requisitos: zzzz zztool' zz/$file
    done

2 - Algumas funções não usam `zztool`:

    for f in zzbeep.sh zzcaracoroa.sh zzcores.sh zzdolar.sh zzestado.sh \
        zzglobo.sh zzhoramin.sh zzmaiores.sh
    do
        gsed -i '/^# Requisitos:/s/ zztool//' $f
    done