### PR TITLE
zztool: Agora funciona -h, --help

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -132,6 +132,8 @@ done
 # ----------------------------------------------------------------------------
 zztool ()
 {
+	zzzz -h tool "$1" && return
+
 	local erro ferramenta
 
 	# Devo mostrar a mensagem de erro?


### PR DESCRIPTION
Por algum motivo, essa função não tinha suporte ao `-h` e `--help`
para mostrar o texto de ajuda.

Arrumado.