### PR TITLE
shellcheck: Arruma falta de aspas (SC2046, SC2086)

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -73,8 +73,8 @@ test "${0##*/}" = 'bash' -o "${0#-}" != "$0" || ZZPATH="$0"
 test -n "$ZZPATH" || ZZPATH=$ZZPATH_DFT
 test "${ZZPATH#/}" = "$ZZPATH" && ZZPATH="$PWD/${ZZPATH#./}"
 
-test -d ${ZZPATH%/*}/zz && ZZDIR="${ZZPATH%/*}/zz"
-test -z "$ZZDIR" && test -d $ZZDIR_DFT && ZZDIR=$ZZDIR_DFT
+test -d "${ZZPATH%/*}/zz" && ZZDIR="${ZZPATH%/*}/zz"
+test -z "$ZZDIR" && test -d "$ZZDIR_DFT" && ZZDIR=$ZZDIR_DFT
 
 # Descobre qual o navegador em modo texto está disponível no sistema
 if test -z "$ZZBROWSER"

--- a/info/autores.sh
+++ b/info/autores.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Listar e datar as funcoeszz e seus autores
 #
-	cd $(dirname "$0") || exit 1
+	cd "$(dirname "$0")" || exit 1
 
 	dir='zz'
 	case "$1" in

--- a/info/desativadas.sh
+++ b/info/desativadas.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Listar e datar funçoes desativadas
 #
-	cd $(dirname "$0") || exit 1
+	cd "$(dirname "$0")" || exit 1
 
 	grep 'DESATIVADA:' ../off/*.sh |
 	sed 's|.*/zz|zz|; s/\.sh:# DESATIVADA:/\t/' |

--- a/info/linhas.sh
+++ b/info/linhas.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Exibe a quantidade de linhas das funcoeszz
 #
-	cd $(dirname "$0") || exit 1
+	cd "$(dirname "$0")" || exit 1
 
 	dir='zz'
 	case "$1" in
@@ -13,19 +13,19 @@
 		zz)
 			for arq in ../zz/*.sh
 			do
-				awk 'END {printf "%4d %s\n", NR, FILENAME}' $arq
+				awk 'END {printf "%4d %s\n", NR, FILENAME}' "$arq"
 			done
 		;;
 		off)
 			for arq in ../off/*.sh
 			do
-				awk 'END {printf "%4d %s\n", NR, FILENAME}' $arq
+				awk 'END {printf "%4d %s\n", NR, FILENAME}' "$arq"
 			done
 		;;
 		tudo)
 			for arq in ../{zz,off}/*.sh
 			do
-				awk 'END {printf "%4d %s\n", NR, FILENAME}' $arq
+				awk 'END {printf "%4d %s\n", NR, FILENAME}' "$arq"
 			done
 		;;
 	esac |

--- a/info/quantidade.sh
+++ b/info/quantidade.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Listar e quantificar as funcoeszz por autor ou ano
 #
-	cd $(dirname "$0") || exit 1
+	cd "$(dirname "$0")" || exit 1
 
 	dir='zz'
 	case "$1" in

--- a/info/requisitos.sh
+++ b/info/requisitos.sh
@@ -1,55 +1,29 @@
 #!/bin/bash
-# Listar dependências e dependentes de cada função
-#
-	cd "$(dirname "$0")" || exit 1
+# Lista dependências e dependentes de cada função
 
-	if test "$1" = "zztool" -o "$1" = "tool"
+cd "$(dirname "$0")/.." || exit 1  # go to repo root
+
+{
+	fzz=$(ls zz/*.sh | sed 's|.*/||;s/\.sh//')
+	requisitos=$(grep 'Requisitos: ' zz/*.sh | sed 's|.*/||;s/\.sh.*:/:/')
+
+	echo "$fzz" |
+	while read arq
+	do
+		unset dependentes
+		echo "$arq"
+		echo "$requisitos" | sed -n "/^$arq:/{s/.*://; s/^/Requisitos: /; p;}"
+		dependentes=$(echo "$requisitos" | grep -E " \<${arq}\>" | cut -d: -f1 | tr '\n' ' ')
+		test -n "$dependentes" && echo "Dependentes: $dependentes"
+		echo
+	done |
+	grep --color=none -B 1 ':' |
+	if test -n "$1"
 	then
-		fzz=$(sed -n '/^zztool/,/simplesmente ignoradas$/{/^		[a-z]/!d;/\(uso\|\erro\))/d;s/	*//;s/)//;s/ | /\
-/g;p;}' ../funcoeszz)
-		test -n "$2" -a "$2" = "--listar" && { echo "$fzz"; exit; }
-
-		requisitos=$(
-			grep -o -E 'zztool (-e )?[[:alnum:]_]+' ../zz/*.sh |
-			sed '/ uso/d;s|.*/||;s/\.sh.*:zztool\( -e\)*/:/' | sort | uniq
-		)
-
-		echo "$fzz" |
-		while read arq
-		do
-			unset dependentes
-			echo "$arq"
-			dependentes=$(echo "$requisitos" | grep -E " \<${arq}\>" | cut -d: -f1 | tr '\n' ' ')
-			test -n "$dependentes" && echo "Dependentes: $dependentes"
-			echo
-		done |
-		if test -n "$2"
-		then
-			grep --color=none -A 1 "^$2$"
-		else
-			cat -
-		fi
+		sed -n "/^$1$/,/--/p"
 	else
-		fzz=$(ls ../zz/*.sh | sed 's|.*/||;s/\.sh//')
-		requisitos=$(grep 'Requisitos: ' ../zz/*.sh | sed 's|.*/||;s/\.sh.*:/:/')
-
-		echo "$fzz" |
-		while read arq
-		do
-			unset dependentes
-			echo "$arq"
-			echo "$requisitos" | sed -n "/^$arq:/{s/.*://; s/^/Requisitos: /; p;}"
-			dependentes=$(echo "$requisitos" | grep -E " \<${arq}\>" | cut -d: -f1 | tr '\n' ' ')
-			test -n "$dependentes" && echo "Dependentes: $dependentes"
-			echo
-		done |
-		grep --color=none -B 1 ':' |
-		if test -n "$1"
-		then
-			sed -n "/^$1$/,/--/p"
-		else
-			cat -
-		fi |
-		sed 's/--//'
+		cat -
 	fi |
-	fmt -s -w "$(tput cols)"
+	sed 's/--//'
+} |
+fmt -s -w "$(tput cols)"

--- a/info/requisitos.sh
+++ b/info/requisitos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Listar dependências e dependentes de cada função
 #
-	cd $(dirname "$0") || exit 1
+	cd "$(dirname "$0")" || exit 1
 
 	if test "$1" = "zztool" -o "$1" = "tool"
 	then
@@ -52,4 +52,4 @@
 		fi |
 		sed 's/--//'
 	fi |
-	fmt -s -w $(tput cols)
+	fmt -s -w "$(tput cols)"

--- a/manpage/generate.sh
+++ b/manpage/generate.sh
@@ -12,7 +12,7 @@
 zz=./funcoeszz.tmp
 out=manpage.t2t
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 
 # The all-in-one script is *way* faster to load
 echo "Generating funcoeszz script..."
@@ -33,11 +33,11 @@ echo "Funções ZZ
 export ZZCOR=0
 for func in $("$zz" zzajuda --lista | cut -d ' ' -f 1)
 do
-	echo $func >&2  # informative
-	
+	echo "$func" >&2  # informative
+
 	echo "= $func =[$func]"
 	echo '```'
-	"$zz" $func -h | sed 1,2d
+	"$zz" "$func" -h | sed 1,2d
 	echo '```'
 done
 

--- a/release/2iso.sh
+++ b/release/2iso.sh
@@ -4,7 +4,7 @@
 #
 # Gera a versão ISO-8859-1 (latin-1) das Funções ZZ
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 
 # Cadê o arquivo de entrada?
 if test -z "$1"

--- a/release/make-release.sh
+++ b/release/make-release.sh
@@ -4,7 +4,7 @@
 #
 # Gera a versão tudo-em-um para o público
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 
 core="../funcoeszz"
 zzdir="../zz"

--- a/testador/missing.sh
+++ b/testador/missing.sh
@@ -2,7 +2,7 @@
 # missing.sh - Show functions not yet tested
 
 # Go to tests folder
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 
 # All zz functions have a counterpart in the test directory?
 for zz_path in ../zz/*

--- a/util/alinhamento.sh
+++ b/util/alinhamento.sh
@@ -6,7 +6,7 @@
 # Procura por espaços em branco em lugares errados.
 
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 
 cd ../zz
 

--- a/util/checkbashisms.sh
+++ b/util/checkbashisms.sh
@@ -9,7 +9,7 @@
 # Man page:
 # http://manpages.ubuntu.com/manpages/lucid/man1/checkbashisms.1.html
 
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 cd ..
 
 eco() { echo -e "\033[36;1m$*\033[m"; }
@@ -17,9 +17,9 @@ eco() { echo -e "\033[36;1m$*\033[m"; }
 for f in zz/*
 do
 	eco ----------------------------------------------------------------
-	eco $f
+	eco "$f"
 	echo '#!/bin/sh' > _tmp
-	cat $f >> _tmp
+	cat "$f" >> _tmp
 	util/checkbashisms.pl -n --extra _tmp
 done
 rm _tmp

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -8,7 +8,7 @@
 # Ex.: metadata.sh autor
 #      metadata.sh versao
 
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 cd ..
 
 tab=$(echo -e '\t')
@@ -20,7 +20,7 @@ case "$1" in
 		sed "s/:# Autor: /$tab/" |
 		while read funcao meta
 		do
-			printf "%-25s %s\n" $funcao $meta
+			printf '%-25s %s\n' "$funcao" "$meta"
 		done
 	;;
 	desde | d)
@@ -40,7 +40,7 @@ case "$1" in
 		sed "s/:# Requisitos: /:/" |
 		while read funcao meta
 		do
-			printf "%-25s %s\n" $funcao $meta
+			printf '%-25s %s\n' "$funcao" "$meta"
 		done
 	;;
 	tags | t)
@@ -49,7 +49,7 @@ case "$1" in
 		sed "s/:# Tags: /:/" |
 		while read funcao meta
 		do
-			printf "%-25s %s\n" $funcao $meta
+			printf '%-25s %s\n' "$funcao" "$meta"
 		done
 	;;
 	nota | n)
@@ -58,7 +58,7 @@ case "$1" in
 		sed "s/:# Nota: /:/" |
 		while read funcao meta
 		do
-			printf "%-25s %s\n" $funcao $meta
+			printf '%-25s %s\n' "$funcao" "$meta"
 		done
 	;;
 esac

--- a/util/missing-requires.sh
+++ b/util/missing-requires.sh
@@ -15,7 +15,7 @@
 #     $
 
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 cd ../zz
 
 grep_var() {  # $1 está presente em $2?

--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -5,7 +5,7 @@
 # Verifica se as funções estão dentro dos padrões
 # Uso: nanny.sh
 
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 cd ..
 
 eco() { echo -e "\033[36;1m$*\033[m"; }
@@ -22,23 +22,23 @@ ls -1 zz/*.sh off/*.sh | grep -v '/zz[a-z0-9]*\.sh$'
 
 eco ----------------------------------------------------------------
 eco "* Funções com erro ao importar (source)"
-for f in zz/*.sh off/*.sh; do (source $f); done
+for f in zz/*.sh off/*.sh; do (source "$f"); done
 
 eco ----------------------------------------------------------------
 eco "* Funções cujo início não é 'zznome ()\\\n'"
-for f in zz/*.sh off/*.sh; do grep "^zz[a-z0-9]* ()$" $f >/dev/null || echo $f; done
+for f in zz/*.sh off/*.sh; do grep "^zz[a-z0-9]* ()$" "$f" >/dev/null || echo "$f"; done
 
 eco ----------------------------------------------------------------
 eco "* Funções que não terminam em '}' na última linha"
-for f in zz/*.sh off/*.sh; do tail -1 $f | grep "^}$" >/dev/null || echo $f; done
+for f in zz/*.sh off/*.sh; do tail -1 "$f" | grep "^}$" >/dev/null || echo "$f"; done
 
 eco ----------------------------------------------------------------
 eco "* Funções que falta a quebra de linha na última linha"
-for f in zz/*.sh off/*.sh; do tail -1 $f | od -a | grep '}.*nl' >/dev/null || echo $f; done
+for f in zz/*.sh off/*.sh; do tail -1 "$f" | od -a | grep '}.*nl' >/dev/null || echo "$f"; done
 
 eco ----------------------------------------------------------------
 eco "* Funções cujo nome não bate com o nome do arquivo"
-for f in zz/*.sh off/*.sh; do grep "^$(basename $f .sh) " $f >/dev/null || echo $f; done
+for f in zz/*.sh off/*.sh; do grep "^$(basename "$f" .sh) " "$f" >/dev/null || echo "$f"; done
 
 
 ### Testes relacionados ao cabeçalho
@@ -114,13 +114,13 @@ do
 
 			# -----------------------------
 			/^# -\{76\}$/! { s/^/Esperava -----------, veio /p; q; }
-		}' $f)
-		test -n "$wrong" && printf "%s: %s\n" $f "$wrong"
+		}' "$f")
+		test -n "$wrong" && printf "%s: %s\n" "$f" "$wrong"
 done
 
 eco ----------------------------------------------------------------
 eco "* Funções cuja linha separadora é estranha"
-for f in zz/*.sh off/*.sh; do test $(egrep -c '^# -{76}$' $f) = 2 || echo $f; done
+for f in zz/*.sh off/*.sh; do test "$(egrep -c '^# -{76}$' "$f")" = 2 || echo "$f"; done
 
 eco ----------------------------------------------------------------
 eco "* Funções com a descrição sem ponto final"
@@ -129,7 +129,7 @@ for f in zz/*.sh off/*.sh; do
 		/^# http/ n
 		# Deve acabar em ponto final
 		/\.$/! p
-		}' $f)
+		}' "$f")
 	test -n "$wrong" && echo "$f: $wrong"
 done
 
@@ -141,7 +141,7 @@ for f in zz/*.sh off/*.sh; do
 		/^# http/ n
 		# Pontos no meio da frase
 		/\. .*\./ p
-		}' $f)
+		}' "$f")
 	test -n "$wrong" && echo "$f: $wrong"
 done
 
@@ -149,7 +149,7 @@ eco ----------------------------------------------------------------
 eco "* Funções com conteúdo inválido no campo Autor:"
 for f in zz/*.sh off/*.sh
 do
-	wrong=$(grep '^# Autor:' $f | egrep -v '^# Autor: [^ ].*$')
+	wrong=$(grep '^# Autor:' "$f" | egrep -v '^# Autor: [^ ].*$')
 	test -n "$wrong" && echo "$f: $wrong"
 done
 
@@ -157,7 +157,7 @@ eco ----------------------------------------------------------------
 eco "* Funções com a data inválida no campo Desde:"
 for f in zz/*.sh off/*.sh
 do
-	wrong=$(grep '^# Desde:' $f | egrep -v '^# Desde: [0-9]{4}-[0-9]{2}-[0-9]{2}$')
+	wrong=$(grep '^# Desde:' "$f" | egrep -v '^# Desde: [0-9]{4}-[0-9]{2}-[0-9]{2}$')
 	test -n "$wrong" && echo "$f: $wrong"
 done
 
@@ -165,7 +165,7 @@ eco ----------------------------------------------------------------
 eco "* Funções com número inválido no campo Versão: (deve ser decimal)"
 for f in zz/*.sh  #off/*.sh
 do
-	wrong=$(grep '^# Versão:' $f | egrep -v '^# Versão: [0-9][0-9]?$')
+	wrong=$(grep '^# Versão:' "$f" | egrep -v '^# Versão: [0-9][0-9]?$')
 	test -n "$wrong" && echo "$f: $wrong"
 done
 
@@ -173,7 +173,7 @@ eco ----------------------------------------------------------------
 eco "* Funções com o campo inválido Licença:"
 for f in zz/*.sh
 do
-	wrong=$(grep '^# Licença:' $f)
+	wrong=$(grep '^# Licença:' "$f")
 	test -n "$wrong" && echo "$f: $wrong"
 done
 
@@ -181,21 +181,21 @@ eco ----------------------------------------------------------------
 eco "* Funções com campo Requisitos: vazio"
 for f in zz/*.sh off/*.sh
 do
-	grep '^# Requisitos: *$' $f > /dev/null && echo $f
+	grep '^# Requisitos: *$' "$f" > /dev/null && echo "$f"
 done
 
 eco ----------------------------------------------------------------
 eco "* Funções com vírgulas no campo Requisitos: (use só espaços)"
 for f in zz/*.sh off/*.sh
 do
-	grep '^# Requisitos:.*,' $f > /dev/null && echo $f
+	grep '^# Requisitos:.*,' "$f" > /dev/null && echo "$f"
 done
 
 eco ----------------------------------------------------------------
 eco "* Funções com cabeçalho >78 colunas"
 for f in zz/*.sh off/*.sh
 do
-	grep '^# ' $f | egrep '^.{79}' |
+	grep '^# ' "$f" | egrep '^.{79}' |
 		grep -v DESATIVADA: |
 		grep -v '^# Requisitos:' |
 		# Insere o path do arquivo no início da linha
@@ -218,7 +218,7 @@ grep -H '^#.*	' zz/*.sh off/*.sh
 # for f in zz/*.sh off/*.sh
 # do
 # 	wrong=$(
-# 		egrep '^# [A-Z][a-z.]+: ' $f |
+# 		egrep '^# [A-Z][a-z.]+: ' "$f" |
 # 		cut -d : -f 1 |
 # 		sed 's/^# //' |
 # 		egrep -v "$campos" |
@@ -234,7 +234,7 @@ eco ----------------------------------------------------------------
 eco "* Funções que não usam 'zzzz -h'"
 for f in zz/*.sh  # off/*.sh
 do
-	grep 'zzzz -h ' $f >/dev/null || echo $f
+	grep 'zzzz -h ' "$f" >/dev/null || echo "$f"
 done
 
 eco ----------------------------------------------------------------
@@ -243,14 +243,14 @@ for f in zz/*.sh  # off/*.sh
 do
 	test "$f" = zz/zzzz.sh && continue  # zzzz lida com seu próprio -h
 	# zzzz -h cores $1 && return
-	fgrep "zzzz -h $(basename $f .sh | sed 's/^zz//') \"\$1\" && return" $f >/dev/null || echo $f
+	fgrep "zzzz -h $(basename "$f" .sh | sed 's/^zz//') \"\$1\" && return" "$f" >/dev/null || echo "$f"
 done
 
 eco ----------------------------------------------------------------
 eco "* Funções com o nome errado em 'zztool uso'"
 for f in zz/*.sh  # off/*.sh
 do
-	wrong=$(grep -E 'zztool( -e)? uso ' $f | grep -vE "zztool( -e)? uso $(basename $f .sh | sed 's/^zz//')")
+	wrong=$(grep -E 'zztool( -e)? uso ' "$f" | grep -vE "zztool( -e)? uso $(basename "$f" .sh | sed 's/^zz//')")
 	test -n "$wrong" && echo "$f"  # && echo "$wrong"
 done
 
@@ -259,7 +259,7 @@ eco "* Funções desativadas sem data e motivo para o desligamento"
 for f in off/*.sh
 do
 	# # DESATIVADA: 2002-10-30 O programa acabou.
-	egrep '^# DESATIVADA: [0-9]{4}-[0-9]{2}-[0-9]{2} .{10,}' $f >/dev/null || echo $f
+	egrep '^# DESATIVADA: [0-9]{4}-[0-9]{2}-[0-9]{2} .{10,}' "$f" >/dev/null || echo "$f"
 done
 
 

--- a/util/requisitos.sh
+++ b/util/requisitos.sh
@@ -10,20 +10,20 @@
 # zzdata.sh: Função lista a si própria como requisito
 #
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 
 cd ../zz
 for f in zz*
 do
 	# Caso especial, já tratado, pode ignorar
-	test $f = 'zzdictodos.sh' && continue
+	test "$f" = 'zzdictodos.sh' && continue
 
 	# Quais as funções já listadas em Requisitos:?
-	requisitos=$(sed -n 's/^# Requisitos://p' $f)
+	requisitos=$(sed -n 's/^# Requisitos://p' "$f")
 
 	# Quais as funções usadas por esta zz?
 	encontradas=$(
-		grep -v '^[ 	]*#' $f |
+		grep -v '^[ 	]*#' "$f" |
 		grep '\bzz[a-z]' |
 		grep -v '()$' |
 		egrep -o '\bzz[a-z0-9]+\b' |
@@ -39,7 +39,7 @@ do
 	done
 
 	# REQUISITO REPETIDO
-	echo $requisitos | tr ' ' '\n' | sort | uniq -d | while read repetida
+	echo "$requisitos" | tr ' ' '\n' | sort | uniq -d | while read repetida
 	do
 		echo "$f: Requisito repetido: $repetida"
 	done
@@ -49,10 +49,10 @@ do
 	for req in $requisitos
 	do
 		# Se o requisito não for uma função zz, ignore
-		echo $req | grep ^zz >/dev/null ||
+		echo "$req" | grep ^zz >/dev/null ||
 			{ echo "$f: $req não é uma funcão zz, registre em 'Notas'" ; continue; }
 
-		echo "$encontradas" | grep -w $req >/dev/null ||
+		echo "$encontradas" | grep -w "$req" >/dev/null ||
 			echo "$f: Função listada mas não utilizada: $req"
 	done
 
@@ -64,14 +64,14 @@ do
 			while read funcao
 			do
 				# Uma função usar ela mesma está OK
-				test $funcao.sh = $f && continue
+				test "$funcao.sh" = "$f" && continue
 
 				# Ignora falsos positivos
-				test $f = zzzz.sh && case "$funcao" in
+				test "$f" = zzzz.sh && case "$funcao" in
 					zzcshrc | zzzshrc) continue;;
 				esac
 
-				echo $requisitos | grep -w $funcao >/dev/null ||
+				echo "$requisitos" | grep -w "$funcao" >/dev/null ||
 					echo "$f: # Requisitos: $funcao"
 			done
 	fi

--- a/util/seguranca.sh
+++ b/util/seguranca.sh
@@ -6,7 +6,7 @@
 
 # TODO receber arquivo individual via argumentos
 
-cd $(dirname "$0") || exit 1
+cd "$(dirname "$0")" || exit 1
 cd ..
 
 eco() { echo -e "\033[36;1m$*\033[m"; }


### PR DESCRIPTION
Esse commit arruma os problemas que o shellcheck
detectou com (falta de) aspas.

https://github.com/koalaman/shellcheck/wiki/SC2046
Quote this to prevent word splitting

https://github.com/koalaman/shellcheck/wiki/SC2086
Double quote to prevent globbing and word splitting
