### PR TITLE
WIP - Usar symlinks para executar funções

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -61,6 +61,19 @@ ZZTMPDIR_DFT="${TMPDIR:-/tmp}"    # diretório temporário
 ZZSEDURL='s| |+|g;s|&|%26|g;s|@|%40|g'
 ZZCODIGOCOR='36;1'            # use zzcores para ver os códigos
 
+# symlink (TODO explain this)
+test -L "$0" &&
+case "$(basename "$0")" in
+	zz?*)
+		zz_func="$(basename "$0")"
+		core_path="$(realpath "$0" 2> /dev/null || readlink -f "$0" 2> /dev/null)"
+		# TODO be more BSD/Mac-friendly
+		"${core_path:?Não consegui achar pra onde aponta o symlink :(}" $zz_func "$@"
+		exit $?
+	;;
+esac
+
+
 #
 ### Truques para descobrir a localização deste arquivo no sistema
 #

--- a/testador/funcoeszz.md
+++ b/testador/funcoeszz.md
@@ -123,3 +123,7 @@ $ zzmaiusculas funciona
 FUNCIONA
 $
 ```
+
+## symlink
+
+TODO


### PR DESCRIPTION
EXPERIMENTAL

A ideia é fazer algo parecido com grep/fgrep/egrep, criando a
possibilidade de se usar symlinks para identificar uma função, apontando
para o script principal `funcoeszz`.

Ou seja, caso o `funcoeszz` detecte que foi chamado como `zzdata`,
`zzcores` ou qualquer outra função ZZ, ele executa aquela função.

Exemplo:

    $ ln -s $PWD/funcoeszz /tmp/zzcalcula
    $ /tmp/zzcalcula 10+5
    15
    $