### PR TITLE
Core e zztool: Substituindo a variável "$ZZSEDURL" por `zztool sedurl`.

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -58,7 +58,6 @@ ZZTMPDIR_DFT="${TMPDIR:-/tmp}"    # diretório temporário
 #
 
 # shellcheck disable=SC2034
-ZZSEDURL='s| |+|g;s|&|%26|g;s|@|%40|g'
 ZZCODIGOCOR='36;1'            # use zzcores para ver os códigos
 
 #

--- a/zz/zzcep.sh
+++ b/zz/zzcep.sh
@@ -29,7 +29,7 @@ zzcep ()
 		cepend="$1"
 	else
 		end=1
-		cepend=$(echo "$*" | zzsemacento | zzminusculas | sed "s/, */-/g;$ZZSEDURL")
+		cepend=$(echo "$*" | zzsemacento | zzminusculas | sed 's/, */-/g' | zztool sedurl)
 	fi
 
 	# A primeira página ou endereço das várias páginas

--- a/zz/zzchavepgp.sh
+++ b/zz/zzchavepgp.sh
@@ -16,7 +16,7 @@ zzchavepgp ()
 	zzzz -h chavepgp "$1" && return
 
 	local url='http://pgp.mit.edu:11371'
-	local padrao=$(echo $* | sed "$ZZSEDURL")
+	local padrao=$(echo $* | zztool sedurl)
 
 	# Verificação dos parâmetros
 	test -n "$1" || { zztool -e uso chavepgp; return 1; }

--- a/zz/zzddd.sh
+++ b/zz/zzddd.sh
@@ -41,7 +41,7 @@ zzddd ()
 		dddend="$1"
 	else
 		end=1
-		dddend=$(echo "$*" | zzsemacento | zzminusculas | sed "s/, */-/g;$ZZSEDURL")
+		dddend=$(echo "$*" | zzsemacento | zzminusculas | sed 's/, */-/g' | zztool sedurl)
 	fi
 
 	# A primeira página ou endereço das várias páginas

--- a/zz/zzdicantonimos.sh
+++ b/zz/zzdicantonimos.sh
@@ -17,7 +17,7 @@ zzdicantonimos ()
 
 	local url='http://www.antonimos.com.br/busca.php'
 	local palavra="$*"
-	local palavra_busca=$( echo "$palavra" | sed "$ZZSEDURL" )
+	local palavra_busca=$( echo "$palavra" | zztool sedurl )
 
 	# Verifica se recebeu parâmetros
 	if test -z "$1"

--- a/zz/zzdicsinonimos.sh
+++ b/zz/zzdicsinonimos.sh
@@ -17,7 +17,7 @@ zzdicsinonimos ()
 
 	local url='http://www.sinonimos.com.br/busca.php'
 	local palavra="$*"
-	local parametro_busca=$( echo "$palavra" | sed "$ZZSEDURL" )
+	local parametro_busca=$( echo "$palavra" | zztool sedurl )
 
 	# Verifica se recebeu parâmetros
 	if test -z "$1"

--- a/zz/zztool.sh
+++ b/zz/zztool.sh
@@ -195,6 +195,10 @@ zztool ()
 				echo "$texto" | sed 's:/:\\\/:g ; s:.*:/&/:'
 			fi
 		;;
+		sedurl)
+			# Formata a url para ser utilizada
+			sed 's| |+|g;s|&|%26|g;s|@|%40|g'
+		;;
 		terminal_utf8)
 			echo "$LC_ALL $LC_CTYPE $LANG" | grep -i utf >/dev/null
 		;;


### PR DESCRIPTION
É uma sugestão, pois o funcionamento da variável era para seu uso em um sed na formatação, integral ou parcial, de uma url.
Mas sua característica e forma de uso parecem mais apropriada estar na ` zztool `, como suporte as demais funções.