### PR TITLE
Arruma ajuda quebrada na versão tudo-em-um

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -140,6 +140,9 @@ _extrai_ajuda() {
 # Limpa conteúdo do arquivo de ajuda
 > "$ZZAJUDA"
 
+# Salva o texto de ajuda das funções inclusas neste arquivo
+# (presentes na versão tudo-em-um)
+test -r "$ZZPATH" && _extrai_ajuda "$ZZPATH" >> "$ZZAJUDA"
 
 ##############################################################################
 #

--- a/testador/funcoeszz.md
+++ b/testador/funcoeszz.md
@@ -123,3 +123,49 @@ $ zzmaiusculas funciona
 FUNCIONA
 $
 ```
+
+## Opção --tudo-em-um
+
+Quando se usa a opção `--tudo-em-um`, uma cópia do arquivo principal `funcoeszz` é gerada, porém com todas as funções das pasta `zz` embutidas dentro dele. Este arquivo gerado é o que usamos quando queremos lançar uma versão nova das Funções ZZ.
+
+Gerar o arquivo é fácil, basta usar a opção e mais nada:
+
+```console
+$ $zz_root/funcoeszz --tudo-em-um > tudo-em-um
+$
+```
+
+Será que todas todas as funções disponíveis foram de fato inseridas no arquivo gerado?
+
+```console
+$ ls -1 $zz_root/zz/ | sed 's/\.sh$//' | sort > originais.txt
+$ grep '^zz.* ()$' tudo-em-um | cut -d ' ' -f 1 | sort > incluidas.txt
+$ diff originais.txt incluidas.txt
+$
+```
+
+Será que a ajuda está funcionando?
+
+```console
+$ bash tudo-em-um zzcalcula -h | grep '^Uso:' | wc -l
+1
+$
+```
+
+Ao gerar a versão tudo-em-um, se existir a variável `$ZZOFF`, ela deve ser respeitada: as funções listadas ali não devem fazer parte do arquivo gerado.
+
+```console
+$ ZZOFF="zzcalcula zzxml" $zz_root/funcoeszz --tudo-em-um > tudo-em-um-off
+$ grep '^zz.* ()$' tudo-em-um-off | cut -d ' ' -f 1 | sort > incluidas.txt
+$ diff originais.txt incluidas.txt | grep '^<'
+< zzcalcula
+< zzxml
+$
+```
+
+Remove todos os arquivos criados pelos testes:
+
+```console
+$ rm tudo-em-um tudo-em-um-off originais.txt incluidas.txt
+$
+```


### PR DESCRIPTION
Desfaz parte do commit 4141711b, que removeu um trecho necessário.

Embora não haja mais nenhuma função ZZ neste arquivo, esse código ainda
é necessário quando o usuário executa a versão oficial, gerada pela
opção `--tudo-em-um`. Nesta versão todas as funções estão dentro do core
e estas linhas restauradas são necessárias para poder extrair os textos
de ajuda.

Também foram adicionados testes para a versão tudo-em-um, para garantir
que esta regressão não aconteça mais no futuro.