### PR TITLE
Remove $ZZCODIGOCOR

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -56,11 +56,6 @@ ZZTMPDIR_DFT="${TMPDIR:-/tmp}"    # diretório temporário
 # Não altere nada aqui.
 #
 #
-
-# shellcheck disable=SC2034
-ZZCODIGOCOR='36;1'            # use zzcores para ver os códigos
-
-#
 ### Truques para descobrir a localização deste arquivo no sistema
 #
 # Se a chamada foi pelo executável, o arquivo é o $0.

--- a/zz/zztool.sh
+++ b/zz/zztool.sh
@@ -16,6 +16,7 @@ zztool ()
 	zzzz -h tool "$1" && return
 
 	local erro ferramenta
+	local cor='36;1'  # ciano (vide saída da zzcores)
 
 	# Devo mostrar a mensagem de erro?
 	test "$1" = '-e' && erro=1 && shift
@@ -40,7 +41,7 @@ zztool ()
 			then
 				printf "%b\n" "$*"
 			else
-				printf "%b\n" "\033[${ZZCODIGOCOR}m$*\033[m"
+				printf "%b\n" "\033[${cor}m$*\033[m"
 			fi
 		;;
 		erro)
@@ -59,7 +60,7 @@ zztool ()
 				then
 					cat -
 				else
-					sed "s/$padrao/${esc}[${ZZCODIGOCOR}m&${esc}[m/g"
+					sed "s/$padrao/${esc}[${cor}m&${esc}[m/g"
 				fi
 		;;
 		grep_var)


### PR DESCRIPTION
O único uso da variável `$ZZCODIGOCOR` era na `zztool`, então ela foi
movida para lá, como uma variável local.

Note que a `$ZZCODIGOCOR` não era uma variável a ser modificada pelo
usuário de qualquer forma. Caso ela existisse no ambiente, não era
respeitada, e no core ela estava na área identificada com "Não altere
nada aqui". Então não há regressão para o usuário.