### PR TITLE
Usa $ZZAJUDA em vez de arquivo no /tmp para o texto de ajuda

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -91,7 +91,6 @@ export ZZBROWSER
 ZZCOR="${ZZCOR:-$ZZCOR_DFT}"
 ZZTMP="${ZZTMPDIR:-$ZZTMPDIR_DFT}"
 ZZTMP="${ZZTMP%/}/zz"  # prefixo comum a todos os arquivos temporários
-ZZAJUDA="$ZZTMP.ajuda"
 unset ZZCOR_DFT ZZPATH_DFT ZZDIR_DFT ZZTMPDIR_DFT
 
 #
@@ -137,8 +136,10 @@ _extrai_ajuda() {
 			}'
 }
 
+zz_ajuda_tmp="$ZZTMP.ajuda"
+
 # Limpa conteúdo do arquivo de ajuda
-> "$ZZAJUDA"
+> "$zz_ajuda_tmp"
 
 
 ##############################################################################
@@ -261,10 +262,10 @@ do
 		# Insere o nome da função na segunda linha
 		sed "2 { h; s/.*/$zz_nome/; G; }"
 
-done < "$ZZTMP.on" >> "$ZZAJUDA"
+done < "$ZZTMP.on" >> "$zz_ajuda_tmp"
 
 # Separador final do arquivo, com exatamente 77 hífens (7x11)
-echo '-------' | sed 's/.*/&&&&&&&&&&&/' >> "$ZZAJUDA"
+echo '-------' | sed 's/.*/&&&&&&&&&&&/' >> "$zz_ajuda_tmp"
 
 
 # Modo --tudo-em-um
@@ -280,11 +281,15 @@ then
 	# Veja issue 5 para mais detalhes:
 	# https://github.com/funcoeszz/funcoeszz/issues/5
 	zz_sed=$(echo "$zz_off" | sed 's@.*@/^&$/,/^----*$/d;@')  # /^zzfoo$/,/^----*$/d
-	cp "$ZZAJUDA" "$ZZAJUDA.2" &&
-	sed "$zz_sed" "$ZZAJUDA.2" > "$ZZAJUDA"
-	rm "$ZZAJUDA.2"
+	cp "$zz_ajuda_tmp" "$zz_ajuda_tmp.2" &&
+	sed "$zz_sed" "$zz_ajuda_tmp.2" > "$zz_ajuda_tmp"
+	rm "$zz_ajuda_tmp.2"
 fi
 
+# Guarda todo o texto de ajuda em uma variável de ambiente e remove o
+# arquivo temporário
+export ZZAJUDA=$(cat "$zz_ajuda_tmp")
+rm "$zz_ajuda_tmp"
 
 ### Carregamento terminado, funções já estão disponíveis
 

--- a/zz/zzajuda.sh
+++ b/zz/zzajuda.sh
@@ -17,23 +17,18 @@ zzajuda ()
 
 	local zzcor_pager
 
-	if test ! -r "$ZZAJUDA"
-	then
-		echo "Ops! Não encontrei o texto de ajuda em '$ZZAJUDA'." >&2
-		echo "Para recriá-lo basta executar o script 'funcoeszz' sem argumentos." >&2
-		return
-	fi
-
 	case "$1" in
 		--uso)
 			# Lista com sintaxe de uso, basta pescar as linhas Uso:
-			sed -n 's/^Uso: zz/zz/p' "$ZZAJUDA" |
+			echo "$ZZAJUDA" |
+				sed -n 's/^Uso: zz/zz/p' |
 				sort |
 				zztool acha '^zz[^ ]*'
 		;;
 		--lista)
 			# Lista de todas as funções no formato: nome descrição
-			grep -A2 ^zz "$ZZAJUDA" |
+			echo "$ZZAJUDA" |
+				grep -A2 ^zz |
 				grep -v ^http |
 				sed '
 					/^zz/ {
@@ -56,7 +51,7 @@ zzajuda ()
 			test "$PAGER" = 'less' -o "$PAGER" = 'more' && zzcor_pager=0
 
 			# Mostra a ajuda de todas as funções, paginando
-			cat "$ZZAJUDA" |
+			echo "$ZZAJUDA" |
 				ZZCOR=${zzcor_pager:-$ZZCOR} zztool acha 'zz[a-z0-9]\{2,\}' |
 				${PAGER:-less -r}
 		;;

--- a/zz/zzzz.sh
+++ b/zz/zzzz.sh
@@ -12,7 +12,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2002-01-07
 # Versão: 1
-# Requisitos: zztool zzajuda
+# Requisitos: zztool
 # ----------------------------------------------------------------------------
 zzzz ()
 {
@@ -74,10 +74,10 @@ zzzz ()
 			# Se o usuário informou a opção de ajuda, mostre o texto
 			if test '-h' = "$arg_func" -o '--help' = "$arg_func"
 			then
-				# Um xunxo bonito: filtra a saída da zzajuda, mostrando
+				# Um xunxo bonito: filtra o conteúdo da $ZZAJUDA, mostrando
 				# apenas a função informada.
 				echo
-				ZZCOR=0 zzajuda |
+				echo "$ZZAJUDA" |
 					sed -n "/^zz$nome_func$/,/^----*$/ {
 						s/^----*$//
 						p


### PR DESCRIPTION
Até então, usávamos um arquivo temporário (dentro da pasta indicada em
`$ZZTMP`) para guardar os textos de ajuda de todas as funções. Então
`zzajuda` e `zzzz -h` usavam o conteúdo deste arquivo para extrair o
texto de ajuda, ou partes dele, quando relevante.

Com este commit, a única coisa que muda da solução anterior é guardar
todos os textos de ajuda numa variável de ambiente `$ZZAJUDA` em vez de
ser no arquivo temporário.

O grande problema da solução anterior é justo o arquivo ser temporário,
então às vezes alguma rotina do próprio sistema vai lá e limpa a pasta
temporária, e foi-se o conteúdo da ajuda. Agora numa variável de
ambiente, ela fica lá disponível e não está sujeita a este apagamento.

O inconveniente desta solução é mostrar uma chuva de texto sempre que se
executa o comando `env` :/

    $ echo "$ZZAJUDA" | wc -l
    2417