### PR TITLE
shellcheck: Arruma SC2162, SC2035, SC2164, SC1007

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -219,7 +219,7 @@ then
 	sed '/^#@$/q' "$ZZPATH"
 
 	# Mostra cada função (ativa), inserindo seu nome na linha 2 do cabeçalho
-	while read zz_nome
+	while read -r zz_nome
 	do
 		zz_arquivo="${ZZDIR%/}"/$zz_nome.sh
 
@@ -244,7 +244,7 @@ then
 fi
 
 # Carregamento das funções ativas, salvando texto de ajuda
-while read zz_nome
+while read -r zz_nome
 do
 	zz_arquivo="${ZZDIR%/}"/$zz_nome.sh
 

--- a/info/requisitos.sh
+++ b/info/requisitos.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.." || exit 1  # go to repo root
 	requisitos=$(grep 'Requisitos: ' zz/*.sh | sed 's|.*/||;s/\.sh.*:/:/')
 
 	echo "$fzz" |
-	while read arq
+	while read -r arq
 	do
 		unset dependentes
 		echo "$arq"
@@ -27,4 +27,3 @@ cd "$(dirname "$0")/.." || exit 1  # go to repo root
 	sed 's/--//'
 } |
 fmt -s -w "$(tput cols)"
-

--- a/manpage/generate.sh
+++ b/manpage/generate.sh
@@ -16,7 +16,7 @@ cd "$(dirname "$0")" || exit 1
 
 # The all-in-one script is *way* faster to load
 echo "Generating funcoeszz script..."
-ZZOFF= ZZDIR=../zz ../funcoeszz --tudo-em-um > $zz
+ZZOFF='' ZZDIR=../zz ../funcoeszz --tudo-em-um > $zz
 chmod +x $zz
 
 (

--- a/util/alinhamento.sh
+++ b/util/alinhamento.sh
@@ -11,19 +11,19 @@ cd "$(dirname "$0")" || exit 1
 cd ../zz
 
 ../funcoeszz tool eco "Linha que inicia com um espaço"
-grep '^ ' * |
+grep '^ ' ./* |
 	grep -v -E '^zz(google|palpite)'  # caso válido, sed multilinha
 
 ../funcoeszz tool eco "Linha com Tab e espaço misturados"
-grep '	 ' * |
+grep '	 ' ./* |
 	# [\t ]: Dentro de colchetes, é regex
 	grep -Fv '[	 ]' |
 	# Em sed para substituição
 	grep -Fv "sed 's"
 
 ../funcoeszz tool eco "Linha com Tabs ou espaços inúteis no final"
-grep '[^ 	][ 	]\{1,\}$' * |
+grep '[^ 	][ 	]\{1,\}$' ./* |
 	grep -v '^zzxml.sh:.*Foo $'  # exceção, usado num comentário
 
 ../funcoeszz tool eco "Linhas vazias, mas com brancos"
-grep -E '^[	 ]+$' *
+grep -E '^[	 ]+$' ./*

--- a/util/alinhamento.sh
+++ b/util/alinhamento.sh
@@ -6,9 +6,8 @@
 # Procura por espaços em branco em lugares errados.
 
 
-cd "$(dirname "$0")" || exit 1
-
-cd ../zz
+cd "$(dirname "$0")/.." || exit 1  # go to repo root
+cd zz || exit 1
 
 ../funcoeszz tool eco "Linha que inicia com um espaço"
 grep '^ ' ./* |

--- a/util/checkbashisms.sh
+++ b/util/checkbashisms.sh
@@ -9,8 +9,7 @@
 # Man page:
 # http://manpages.ubuntu.com/manpages/lucid/man1/checkbashisms.1.html
 
-cd "$(dirname "$0")"
-cd ..
+cd "$(dirname "$0")/.." || exit 1  # go to repo root
 
 eco() { echo -e "\033[36;1m$*\033[m"; }
 

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -18,7 +18,7 @@ case "$1" in
 		IFS="$tab"
 		grep '# Autor:' zz/*.sh off/*.sh |
 		sed "s/:# Autor: /$tab/" |
-		while read funcao meta
+		while read -r funcao meta
 		do
 			printf '%-25s %s\n' "$funcao" "$meta"
 		done
@@ -38,7 +38,7 @@ case "$1" in
 		IFS=':'
 		grep '# Requisitos:' zz/*.sh off/*.sh |
 		sed "s/:# Requisitos: /:/" |
-		while read funcao meta
+		while read -r funcao meta
 		do
 			printf '%-25s %s\n' "$funcao" "$meta"
 		done
@@ -47,7 +47,7 @@ case "$1" in
 		IFS=':'
 		grep '# Tags:' zz/*.sh off/*.sh |
 		sed "s/:# Tags: /:/" |
-		while read funcao meta
+		while read -r funcao meta
 		do
 			printf '%-25s %s\n' "$funcao" "$meta"
 		done
@@ -56,7 +56,7 @@ case "$1" in
 		IFS=':'
 		grep '^# Nota: \(requer \|opcional \|(ou) \)' zz/*.sh off/*.sh |
 		sed "s/:# Nota: /:/" |
-		while read funcao meta
+		while read -r funcao meta
 		do
 			printf '%-25s %s\n' "$funcao" "$meta"
 		done

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -8,8 +8,7 @@
 # Ex.: metadata.sh autor
 #      metadata.sh versao
 
-cd "$(dirname "$0")"
-cd ..
+cd "$(dirname "$0")/.." || exit 1  # go to repo root
 
 tab=$(echo -e '\t')
 

--- a/util/missing-requires.sh
+++ b/util/missing-requires.sh
@@ -33,7 +33,7 @@ do
 		grep "^zz" |
 
 		# Any of these are missing in the original list?
-		while read required
+		while read -r required
 		do
 			grep_var " $required " " $* " || echo "$required"
 		done

--- a/util/missing-requires.sh
+++ b/util/missing-requires.sh
@@ -15,8 +15,8 @@
 #     $
 
 
-cd "$(dirname "$0")" || exit 1
-cd ../zz
+cd "$(dirname "$0")/.." || exit 1  # go to repo root
+cd zz || exit 1
 
 grep_var() {  # $1 está presente em $2?
 	test "${2#*$1}" != "$2"
@@ -40,4 +40,3 @@ do
 done |
 sort |
 uniq
-

--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -5,8 +5,7 @@
 # Verifica se as funções estão dentro dos padrões
 # Uso: nanny.sh
 
-cd "$(dirname "$0")"
-cd ..
+cd "$(dirname "$0")/.." || exit 1  # go to repo root
 
 eco() { echo -e "\033[36;1m$*\033[m"; }
 

--- a/util/requisitos.sh
+++ b/util/requisitos.sh
@@ -10,9 +10,9 @@
 # zzdata.sh: Função lista a si própria como requisito
 #
 
-cd "$(dirname "$0")" || exit 1
+cd "$(dirname "$0")/.." || exit 1  # go to repo root
+cd zz || exit 1
 
-cd ../zz
 for f in zz*
 do
 	# Caso especial, já tratado, pode ignorar

--- a/util/requisitos.sh
+++ b/util/requisitos.sh
@@ -39,7 +39,7 @@ do
 	done
 
 	# REQUISITO REPETIDO
-	echo "$requisitos" | tr ' ' '\n' | sort | uniq -d | while read repetida
+	echo "$requisitos" | tr ' ' '\n' | sort | uniq -d | while read -r repetida
 	do
 		echo "$f: Requisito repetido: $repetida"
 	done
@@ -61,7 +61,7 @@ do
 	if test -n "$encontradas"
 	then
 		echo "$encontradas" |
-			while read funcao
+			while read -r funcao
 			do
 				# Uma função usar ela mesma está OK
 				test "$funcao.sh" = "$f" && continue


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/wiki/SC2162
read without -r will mangle backslashes

https://github.com/koalaman/shellcheck/wiki/SC2035
Use `./*glob*` or `-- *glob*` so names with dashes won't become options

https://github.com/koalaman/shellcheck/wiki/SC2164
Use cd ... || exit in case cd fails

https://github.com/koalaman/shellcheck/wiki/SC1007
Remove space after = if trying to assign a value


