### PR TITLE
Requer ZZPATH ou ZZDIR para mostrar a ajuda

### DIFF
--- a/funcoeszz
+++ b/funcoeszz
@@ -86,7 +86,6 @@ export ZZBROWSER
 ZZCOR="${ZZCOR:-$ZZCOR_DFT}"
 ZZTMP="${ZZTMPDIR:-$ZZTMPDIR_DFT}"
 ZZTMP="${ZZTMP%/}/zz"  # prefixo comum a todos os arquivos temporários
-ZZAJUDA="$ZZTMP.ajuda"
 unset ZZCOR_DFT ZZPATH_DFT ZZDIR_DFT ZZTMPDIR_DFT
 
 #
@@ -111,42 +110,12 @@ done
 
 ##############################################################################
 #
-#                             Texto de ajuda
-#                             --------------
-#
-#
-
-# Função temporária para extrair o texto de ajuda do cabeçalho das funções
-# Passe o arquivo com as funções como parâmetro
-_extrai_ajuda() {
-	# Extrai somente os cabeçalhos, já removendo o # do início
-	sed -n '/^# -----* *$/,/^# -----* *$/ s/^# \{0,1\}//p' "$1" |
-		# Agora remove trechos que não podem aparecer na ajuda
-		sed '
-			# Apaga a metadata (Autor, Desde, Versao, etc)
-			/^Autor:/,/^------/ d
-
-			# Apaga a linha em branco apos Ex.:
-			/^Ex\.:/,/^------/ {
-				/^ *$/d
-			}'
-}
-
-# Limpa conteúdo do arquivo de ajuda
-> "$ZZAJUDA"
-
-# Salva o texto de ajuda das funções inclusas neste arquivo
-# (presentes na versão tudo-em-um)
-test -r "$ZZPATH" && _extrai_ajuda "$ZZPATH" >> "$ZZAJUDA"
-
-##############################################################################
-#
 #                    Carregamento das funções do $ZZDIR
 #                    ----------------------------------
 #
 # O carregamento é feito em dois passos para ficar mais robusto:
 # 1. Obtenção da lista completa de funções, ativadas e desativadas.
-# 2. Carga de cada função ativada, salvando o texto de ajuda.
+# 2. Carga de cada função ativada.
 #
 # Com a opção --tudo-em-um, o passo 2 é alterado para mostrar o conteúdo
 # da função em vez de carregá-la.
@@ -254,16 +223,7 @@ do
 	# Inclui a função na shell atual
 	. "$zz_arquivo"
 
-	# Extrai o texto de ajuda
-	_extrai_ajuda "$zz_arquivo" |
-		# Insere o nome da função na segunda linha
-		sed "2 { h; s/.*/$zz_nome/; G; }"
-
-done < "$ZZTMP.on" >> "$ZZAJUDA"
-
-# Separador final do arquivo, com exatamente 77 hífens (7x11)
-echo '-------' | sed 's/.*/&&&&&&&&&&&/' >> "$ZZAJUDA"
-
+done < "$ZZTMP.on"
 
 # Modo --tudo-em-um
 # Todas as funções já foram carregadas por estarem dentro deste arquivo.
@@ -273,14 +233,6 @@ if test -z "$ZZDIR" -a -n "$zz_off"
 then
 	# Desliga todas em uma só linha (note que não usei aspas)
 	unset $zz_off
-
-	# Agora apaga os textos da ajuda, montando um script em sed e aplicando
-	# Veja issue 5 para mais detalhes:
-	# https://github.com/funcoeszz/funcoeszz/issues/5
-	zz_sed=$(echo "$zz_off" | sed 's@.*@/^&$/,/^----*$/d;@')  # /^zzfoo$/,/^----*$/d
-	cp "$ZZAJUDA" "$ZZAJUDA.2" &&
-	sed "$zz_sed" "$ZZAJUDA.2" > "$ZZAJUDA"
-	rm "$ZZAJUDA.2"
 fi
 
 
@@ -291,8 +243,6 @@ fi
 unset zz_arquivo
 unset zz_nome
 unset zz_off
-unset zz_sed
-unset -f _extrai_ajuda
 
 
 ##----------------------------------------------------------------------------

--- a/zz/zzajuda.sh
+++ b/zz/zzajuda.sh
@@ -1,62 +1,125 @@
 # ----------------------------------------------------------------------------
-# Mostra uma tela de ajuda com explicação e sintaxe de todas as funções.
+# Mostra o texto de ajuda da função informada (ou de todas).
 # Opções: --lista  lista de todas as funções, com sua descrição
 #         --uso    resumo de todas as funções, com a sintaxe de uso
-# Uso: zzajuda [--lista|--uso]
-# Ex.: zzajuda
+# Uso: zzajuda [--lista|--uso] [nome-da-função]
+# Ex.: zzajuda            # mostra a ajuda de todas as funções
+#      zzajuda zzdata     # mostra a ajuda da zzdata
 #      zzajuda --lista
 #
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2000-05-04
-# Versão: 1
+# Versão: 2
 # Requisitos: zzzz zztool
 # ----------------------------------------------------------------------------
 zzajuda ()
 {
 	zzzz -h ajuda "$1" && return
 
+	local func
+	local path
+	local separador
 	local zzcor_pager
-
-	if test ! -r "$ZZAJUDA"
-	then
-		echo "Ops! Não encontrei o texto de ajuda em '$ZZAJUDA'." >&2
-		echo "Para recriá-lo basta executar o script 'funcoeszz' sem argumentos." >&2
-		return
-	fi
 
 	case "$1" in
 		--uso)
+			shift
 			# Lista com sintaxe de uso, basta pescar as linhas Uso:
-			sed -n 's/^Uso: zz/zz/p' "$ZZAJUDA" |
+			# Funciona para uma ou todas as funções
+			zzajuda "$@" |
+				sed -n 's/^Uso: //p' |
 				sort |
 				zztool acha '^zz[^ ]*'
 		;;
 		--lista)
-			# Lista de todas as funções no formato: nome descrição
-			grep -A2 ^zz "$ZZAJUDA" |
-				grep -v ^http |
-				sed '
-					/^zz/ {
-						# Padding: o nome deve ter 17 caracteres
-						# Maior nome: zzfrenteverso2pdf
-						:pad
-						s/^.\{1,16\}$/& /
-						t pad
-
-						# Junta a descricao (proxima linha)
-						N
-						s/\n/ /
-					}' |
-				grep ^zz |
-				sort |
+			local texto
+			while read -r func
+			do
+				texto=$(
+					zzajuda "$func" |
+					grep -v ^http |
+					head -n 1
+				)
+				printf '%-17s%s\n' "$func" "$texto"
+			done < "$ZZTMP.on" |
 				zztool acha '^zz[^ ]*'
 		;;
+		zz*)
+			func="$1"
+
+			test -n "$ZZPATH" && path="$ZZPATH"
+			test -n "$ZZDIR" && path="$ZZDIR/$func.sh"
+			test -n "$path" || {
+				echo "Ops! Não consigo encontrar o texto de ajuda." >&2
+				echo "Você precisa definir a variável ZZPATH ou a ZZDIR." >&2
+				return
+			}
+			test -r "$path" || {
+				echo "Erro: Não consigo ler o arquivo $path" >&2
+				echo "Essa path foi determinado com base em:" >&2
+				echo "ZZPATH='$ZZPATH'" >&2
+				echo "ZZDIR='$ZZDIR'" >&2
+				return
+			}
+
+			# Extrai o texto de ajuda
+			# Nota: Os comentários do script sed estão sem acentos,
+			#       para evitar qualquer tipo de problema com UTF-8.
+			sed -n '
+				# Para cada bloco de texto de ajuda que encontrar,
+				# guarde o conteudo relevante no hold space.
+				/^# -----* *$/,/^# -----* *$/ {
+
+					# Apaga a metadata (Autor, Desde, Versao, etc)
+					/^# Autor:/,/^# -----* *$/ d
+
+					# Apaga a primeira linha separadora
+					/^# -----* *$/ d
+
+					# Remove o caractere de comentario
+					s/^# \{0,1\}//
+
+					# Anexa o conteudo no hold space
+					H
+				}
+
+				# Se logo em sequida ao bloco de ajuda aparecer a funcao
+				# que estamos buscando, mostre o texto de ajuda guardado
+				# no hold space e saia (quit), porque ja obtivemos o que
+				# queriamos.
+				'"/^$func ()/"' {
+					g
+
+					# Remove linhas em branco do inicio e fim
+					s/^\n*//
+					s/\n*$//
+
+					p
+					q
+				}
+
+				# Se o bloco de ajuda atual for de qualquer outra
+				# funcao, basta descartá-lo e limpar o hold space para o
+				# próximo bloco
+				/^zz[^ ]* ()/ {
+					s/.*//
+					h
+				}
+			' "$path"
+		;;
 		*)
+			# Linha separadora com exatamente 77 hífens (7x11)
+			separador=$(echo '-------' | sed 's/.*/&&&&&&&&&&&/'
+)
 			# Desliga cores para os paginadores antigos
 			test "$PAGER" = 'less' -o "$PAGER" = 'more' && zzcor_pager=0
 
 			# Mostra a ajuda de todas as funções, paginando
-			cat "$ZZAJUDA" |
+			while read -r func
+			do
+				echo "$separador"
+				zzajuda "$func"
+			done < "$ZZTMP.on" |
 				ZZCOR=${zzcor_pager:-$ZZCOR} zztool acha 'zz[a-z0-9]\{2,\}' |
 				${PAGER:-less -r}
 		;;

--- a/zz/zzzz.sh
+++ b/zz/zzzz.sh
@@ -74,15 +74,9 @@ zzzz ()
 			# Se o usuário informou a opção de ajuda, mostre o texto
 			if test '-h' = "$arg_func" -o '--help' = "$arg_func"
 			then
-				# Um xunxo bonito: filtra a saída da zzajuda, mostrando
-				# apenas a função informada.
 				echo
-				ZZCOR=0 zzajuda |
-					sed -n "/^zz$nome_func$/,/^----*$/ {
-						s/^----*$//
-						p
-					}" |
-					zztool acha zz$nome_func
+				zzajuda zz$nome_func | zztool acha zz$nome_func
+				echo
 				return 0
 			else
 


### PR DESCRIPTION
A ideia aqui é a seguinte: para que as funções funcionem 100%, é
necessário que ou `$ZZPATH` ou `$ZZDIR` estejam setados corretamente na
shell do usuário.

Com essa premissa, o texto de ajuda pode ser sempre obtido dinamicamente
direto do arquivo que contém a função, seja ele o tudo-em-um ou algum
`zz/*`, eliminando a necessidade de existir o arquivo `$ZZTMP.ajuda`.