### PR TITLE
testador/run: Ignora ZZOFF do ambiente do usuário

### DIFF
--- a/testador/run
+++ b/testador/run
@@ -32,7 +32,7 @@ $tester -V > /dev/null || {
 
 # Create temporary file with ZZ init in full paths
 cat > "$tmp" <<EOF
-. "$zz_root"/funcoeszz \\
+ZZOFF='' . "$zz_root"/funcoeszz \\
 	--cor 0 \\
 	--path "$zz_root"/funcoeszz \\
 	--dir  "$zz_root"/zz


### PR DESCRIPTION
A variável de ambiente ZZOFF estava influenciando os testes, porque não
estávamos desligando-na explicitamente ao dar source no funcoeszz na
fase de pre-flight do testador. Agora isso está explícito.

Sem ZZOFF no ambiente, os testes da `zzzz` passavam:

    $ unset ZZOFF
    $ ./testador/run zzzz.sh
    ...........
    OK: 11 of 11 tests passed

Mas quando o usuário definia a ZZOFF, isso afetava os testes:

    $ export ZZOFF="zzxml"
    $ ./testador/run zzzz.sh
    ...
    --------------------------------------------------------------------
    [FAILED #3, line 46] zzzz | grep '(' | tr -d 0-9 | sed 's/) .*/) .../'
    @@ -8,3 +8,4 @@
    (  zshrc) ...
    (   site) ...
    ((  funções disponíveis ))
    +((  funções desativadas ))
    --------------------------------------------------------------------
    ........

    FAIL: 1 of 11 tests failed