### PR TITLE
util/requisitos.sh: Novo falso-positivo na zztool

### DIFF
--- a/util/requisitos.sh
+++ b/util/requisitos.sh
@@ -66,7 +66,10 @@ do
 				# Uma função usar ela mesma está OK
 				test "$funcao.sh" = "$f" && continue
 
-				# Ignora falsos positivos
+				# Falso-positivo: zzcores é mencionada em um comentário
+				test "$f" = zztool.sh && test "$funcao" = zzcores && continue
+
+				# Falso-positivo: estes são nomes de arquivos
 				test "$f" = zzzz.sh && case "$funcao" in
 					zzcshrc | zzzshrc) continue;;
 				esac


### PR DESCRIPTION
A mudança recente na PR #702 adicionou um comentário na zztool que
passou a ser considerado um problema pelo script de requisitos:

    $ ./util/requisitos.sh
    zztool.sh: # Requisitos: zzcores
    $

Agora o comentário é ignorado.