### PR TITLE
CI: Agora executa o util/requisitos.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - mv clitest testador
 
 script:
+  - ./util/requisitos.sh
   - ./testador/run funcoeszz.md
   - ./testador/run internet_travis
 

--- a/util/requisitos.sh
+++ b/util/requisitos.sh
@@ -75,4 +75,7 @@ do
 					echo "$f: # Requisitos: $funcao"
 			done
 	fi
-done
+done | {
+	# Garante que o exit code é 1 se este script produzir qualquer output
+	! grep .
+}


### PR DESCRIPTION
O script requisitos.sh foi modificado para sair com exit code 1 caso
qualquer problema de requisitos seja encontrado.

Agora com o exit code correto, ele pode ser adicionado no Travis CI
para que possamos perceber problemas de requisitos assim que eles são
criados.

Um exemplo que poderia ter sido evitado foi o caso da PR #708.