### PR TITLE
testador: zzzz: Adiciona teste com ZZOFF

### DIFF
--- a/testador/zzzz.sh
+++ b/testador/zzzz.sh
@@ -11,6 +11,10 @@ Uso: zzzz [--atualiza|--teste|--bashrc|--tcshrc|--zshrc]
 Ex.: zzzz
      zzzz --teste
 
+$
+
+# Testa a opção --teste
+
 $ zzzz --teste | sed 's/\.\.\. .*/.../;/Atenção/,/^Talvez/d;/^ *$/d'
 Procurando o comando awk...
 Procurando o comando bc...
@@ -43,6 +47,10 @@ Procurando o comando uniq...
 Procurando o comando unzip...
 Verificando a codificação do sistema...
 Verificando a codificação das Funções ZZ...
+$
+
+# Testa saída da zzzz sem argumentos
+
 $ zzzz | grep '(' | tr -d 0-9 | sed 's/) .*/) .../'
 ( script) ...
 (  pasta) ...
@@ -54,6 +62,25 @@ $ zzzz | grep '(' | tr -d 0-9 | sed 's/) .*/) .../'
 (  zshrc) ...
 (   site) ...
 ((  funções disponíveis ))
+$
+
+# Lista de funções desligadas só aparece no final, não nas disponíveis.
+# Nestes testes foi criada uma pasta ZZTMPDIR alternativa para gerar os
+# arquivos .on e .off sem bagunçar os "oficiais".
+
+$ zzzz_tmp="/tmp/testador-zzzz-$$"
+$ mkdir "$zzzz_tmp"
+$ ZZTMPDIR="$zzzz_tmp" ZZOFF="zzdata zzcores" ../funcoeszz
+$ cat "$zzzz_tmp/zz.off"
+zzcores
+zzdata
+$ ZZTMP="$zzzz_tmp/zz" zzzz | tail -n 2
+(( 2 funções desativadas ))
+cores, data
+$ ZZTMP="$zzzz_tmp/zz" zzzz | sed -n '/disponíveis/,/^$/ p' | grep -E '\b(cores|data),'
+$ rm "$zzzz_tmp"/zz*
+$ rmdir "$zzzz_tmp"
+$ unset zzzz_tmp
 $
 
 # As variáveis de ambiente devem ser respeitadas


### PR DESCRIPTION
Caso a variável `$ZZOFF` esteja definida, a saída da `zzzz` sem
argumentos é modificada. No final aparece uma seção nova listando as
funções desativadas. Exemplo:

    $ ZZOFF="zzdata zzcores" ./funcoeszz zzzz
    ...

    (( 188 funções disponíveis ))
    ajuda, aleatorio, alfabeto, alinhar, ansi2html, arrumacidade,
    ...
    vds, vira, wc, wikipedia, xml, zz

    (( 2 funções desativadas ))
    cores, data
    $

Agora os testes verificam se esta funcionalidade está ok.

Os testes acabaram ficando um pouco complexos, devido a ter que criar os
arquivos `.on` e `.off` em uma pasta alternativa, pra não sobrescrever
os oficiais.