### PR TITLE
CI: Adiciona GitHub Actions (sandbox)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,6 +82,7 @@ jobs:
           python3 -c 'from subprocess import run; run(["./testador/run zztempo.sh"], shell=True, check=True)'
 
       - name: zzconfere
+        continue-on-error: true
         env:
           ZZTMPDIR: /home/runner/work
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,12 +48,6 @@ jobs:
           mv clitest testador
 
       # debug
-      - run: uname -a
-      - run: env
-      - run: id
-      - run: pwd
-      - run: which sed
-      - run: sed --version
       - run: ./funcoeszz zzzz
       - run: ./funcoeszz zzconjugar comemorar def || true
       - run: ./funcoeszz zzloteria federal 2500 || true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -74,6 +74,12 @@ jobs:
           chmod +x clitest
           mv clitest testador
 
+      - name: zztempo
+        env:
+          TERM: xterm  # fix da zztempo
+        run: |
+          python3 -c 'from subprocess import run; run(["./testador/run zztempo.sh"], shell=True, check=True)'
+
       - name: Run the tests
         env:
           TERM: xterm  # fix da zztempo

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,13 +10,51 @@ jobs:
       - uses: actions/checkout@v2
       - run: ./util/requisitos.sh
 
-  test:
-    runs-on: ubuntu-latest
+  test-ubuntu-16:
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
 
       - name: Install dependencies (apt)
-        run: sudo apt-get install bc links
+        run: sudo apt-get install links
+
+      - name: Install clitest
+        run: |
+          curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
+          chmod +x clitest
+          mv clitest testador
+
+      - name: Run the tests
+        run: |
+          ./testador/run funcoeszz.md
+          ./testador/run internet_travis
+
+  test-ubuntu-18:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies (apt)
+        run: sudo apt-get install links
+
+      - name: Install clitest
+        run: |
+          curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
+          chmod +x clitest
+          mv clitest testador
+
+      - name: Run the tests
+        run: |
+          ./testador/run funcoeszz.md
+          ./testador/run internet_travis
+
+  test-ubuntu-20:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies (apt)
+        run: sudo apt-get install links
 
       - name: Install clitest
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,53 +10,53 @@ jobs:
       - uses: actions/checkout@v2
       - run: ./util/requisitos.sh
 
-  test-ubuntu-16:
-    runs-on: ubuntu-16.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies (apt)
-        run: |
-          sudo apt-get install bc links
-          ./funcoeszz zzzz --teste
-
-      - name: Install clitest
-        run: |
-          curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
-          chmod +x clitest
-          mv clitest testador
-
-      - name: Run the tests
-        run: |
-          ./testador/run funcoeszz.md
-          ./testador/run internet_travis
-
-  test-ubuntu-18:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies (apt)
-        run: |
-          sudo apt-get install links
-          ./funcoeszz zzzz --teste
-
-      - name: Install clitest
-        run: |
-          curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
-          chmod +x clitest
-          mv clitest testador
-
-      # debug
-      - run: ./funcoeszz zzzz
-      - run: ./funcoeszz zzconjugar comemorar def || true
-      - run: ./funcoeszz zzloteria federal 2500 || true
-      - run: ./funcoeszz zznerdcast | wc -l || true
-
-      - name: Run the tests
-        run: |
-          ./testador/run funcoeszz.md
-          ./testador/run internet_travis
+#  test-ubuntu-16:
+#    runs-on: ubuntu-16.04
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - name: Install dependencies (apt)
+#        run: |
+#          sudo apt-get install bc links
+#          ./funcoeszz zzzz --teste
+#
+#      - name: Install clitest
+#        run: |
+#          curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
+#          chmod +x clitest
+#          mv clitest testador
+#
+#      - name: Run the tests
+#        run: |
+#          ./testador/run funcoeszz.md
+#          ./testador/run internet_travis
+#
+#  test-ubuntu-18:
+#    runs-on: ubuntu-18.04
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - name: Install dependencies (apt)
+#        run: |
+#          sudo apt-get install links
+#          ./funcoeszz zzzz --teste
+#
+#      - name: Install clitest
+#        run: |
+#          curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
+#          chmod +x clitest
+#          mv clitest testador
+#
+#      # debug
+#      - run: ./funcoeszz zzzz
+#      - run: ./funcoeszz zzconjugar comemorar def || true
+#      - run: ./funcoeszz zzloteria federal 2500 || true
+#      - run: ./funcoeszz zznerdcast | wc -l || true
+#
+#      - name: Run the tests
+#        run: |
+#          ./testador/run funcoeszz.md
+#          ./testador/run internet_travis
 
   test-ubuntu-20:
     runs-on: ubuntu-20.04

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,6 +81,8 @@ jobs:
           mv clitest testador
 
       - name: Run the tests
+        env:
+          TERM: xterm  # fix da zztempo
         run: |
-          python3 -c 'from subprocess import run; run(["./testador/run funcoeszz.md"], shell=True)'
-          python3 -c 'from subprocess import run; run(["./testador/run internet_travis"], shell=True)'
+          python3 -c 'from subprocess import run; run(["./testador/run funcoeszz.md"], shell=True, check=True)'
+          python3 -c 'from subprocess import run; run(["./testador/run internet_travis"], shell=True, check=True)'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,30 @@
+# https://docs.github.com/en/actions/reference
+
+name: Check
+on: push
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./util/requisitos.sh
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies (apt)
+        run: sudo apt-get install bc links
+
+      - name: Install clitest
+        run: |
+          curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
+          chmod +x clitest
+          mv clitest testador
+
+      - name: Run the tests
+        run: |
+          ./testador/run funcoeszz.md
+          ./testador/run internet_travis

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,10 @@ jobs:
       - run: pwd
       - run: which sed
       - run: sed --version
+      - run: ./funcoeszz zzzz
+      - run: ./funcoeszz zzconjugar comemorar def || true
+      - run: ./funcoeszz zzloteria federal 2500 || true
+      - run: ./funcoeszz zznerdcast | wc -l || true
 
       - name: Run the tests
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,6 +75,7 @@ jobs:
           mv clitest testador
 
       - name: zztempo
+        continue-on-error: true
         env:
           TERM: xterm  # fix da zztempo
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,5 +82,5 @@ jobs:
 
       - name: Run the tests
         run: |
-          ./testador/run funcoeszz.md
-          ./testador/run internet_travis
+          python3 -c 'from subprocess import run; run(["./testador/run funcoeszz.md"], shell=True)'
+          python3 -c 'from subprocess import run; run(["./testador/run internet_travis"], shell=True)'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,6 +47,14 @@ jobs:
           chmod +x clitest
           mv clitest testador
 
+      # debug
+      - run: uname -a
+      - run: env
+      - run: id
+      - run: pwd
+      - run: which sed
+      - run: sed --version
+
       - name: Run the tests
         run: |
           ./testador/run funcoeszz.md

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies (apt)
-        run: sudo apt-get install links
+        run: |
+          sudo apt-get install bc links
+          ./funcoeszz zzzz --teste
 
       - name: Install clitest
         run: |
@@ -35,7 +37,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies (apt)
-        run: sudo apt-get install links
+        run: |
+          sudo apt-get install links
+          ./funcoeszz zzzz --teste
 
       - name: Install clitest
         run: |
@@ -54,7 +58,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies (apt)
-        run: sudo apt-get install links
+        run: |
+          sudo apt-get install links
+          ./funcoeszz zzzz --teste
 
       - name: Install clitest
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,6 +80,12 @@ jobs:
         run: |
           python3 -c 'from subprocess import run; run(["./testador/run zztempo.sh"], shell=True, check=True)'
 
+      - name: zzconfere
+        env:
+          ZZTMPDIR: /home/runner/work
+        run: |
+          python3 -c 'from subprocess import run; run(["./testador/run zzconfere.sh"], shell=True, check=True)'
+
       - name: Run the tests
         env:
           TERM: xterm  # fix da zztempo

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ before_install:
 
 script:
   - ./util/requisitos.sh
-  - ./testador/run zzloteria.sh
   - ./testador/run funcoeszz.md
-# - ./testador/run internet_travis
+  - ./testador/run internet_travis
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_install:
 
 script:
   - ./util/requisitos.sh
+  - ./testador/run zzloteria.sh
   - ./testador/run funcoeszz.md
-  - ./testador/run internet_travis
+# - ./testador/run internet_travis
 
 notifications:
   email: false

--- a/zz/zzloteria.sh
+++ b/zz/zzloteria.sh
@@ -281,7 +281,8 @@ zzloteria ()
 					if ! test -e ${cache}.quina.htm || ! $(zztool dump ${cache}.quina.htm | grep "^ *$num_con " >/dev/null)
 					then
 						wget -q -O "${cache}.quina.zip" "http://www1.caixa.gov.br/loterias/_arquivos/loterias/D_quina.zip"
-						$un_zip "${cache}.quina.zip" "*.htm" -d "$tmp_dir" 2>/dev/null
+						$un_zip "${cache}.quina.zip" "*.htm" -d "$tmp_dir" #2>/dev/null
+                        ls -la "$tmp_dir"
 						mv -f "${tmp_dir}/d_quina.htm" ${cache}.quina.htm
 						rm -f ${cache}.quina.zip
 					fi


### PR DESCRIPTION
Testes gerais do CI do GitHub, para poder comparar com e substituir o Travis CI.

Note que já estamos usando o GitHub Actions de fato desde a PR #737