### PR TITLE
testador: Baixa clitest se necessário

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ addons:
       - bc
       - links
 
-before_install:
-  - curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
-  - chmod +x clitest
-  - mv clitest testador
-
 script:
   - ./util/requisitos.sh
   - ./testador/run funcoeszz.md

--- a/testador/run
+++ b/testador/run
@@ -22,12 +22,10 @@ internet_travis=$(echo "$internet" | grep -E -v '^zz(distro|linux|chavepgp)\.sh$
 all=$(ls -1 zz*.sh)
 no_internet=$(echo "$all" | grep -F -v -x -f <(echo "$internet"))
 
-# Check requirements
-$tester -V > /dev/null || {
-	printf '%s\n' "Ops... Não achei o programa testador: clitest"
-	printf '%s\n' 'Baixe-o deste endereço:'
-	printf '%s\n' 'https://raw.github.com/aureliojargas/clitest/master/clitest'
-	exit 1
+# Download clitest if necessary
+$tester -V > /dev/null 2>&1 || {
+	echo "Baixando clitest..."
+	curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
 }
 
 # Create temporary file with ZZ init in full paths


### PR DESCRIPTION
Não tem sentido só mostrar uma mensagem de erro, sendo que o clitest é
requisito obrigatório para rodar os testes.

Ademais, não é preciso tornar o arquivo baixado executável, e nesse
ponto já estamos na pasta certa onde ele deve estar (`testador/`). Então
basta somente baixar o script e mais nada.