### PR TITLE
Adiciona Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ addons:
       - links
 
 before_install:
-  - curl -sOL https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
-  - chmod +x clitest
-  - mv clitest testador
+  - make testador/clitest
 
 script:
-  - ./util/requisitos.sh
-  - ./util/nanny.sh
-  - ./testador/run funcoeszz.md
+  - make lint
+  - make test-core
   - ./testador/run internet_travis
 
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+clitest = testador/clitest
+clitest_url = https://raw.githubusercontent.com/aureliojargas/clitest/master/clitest
+
+.PHONY: clean lint test test-core test-local test-internet
+
+lint:
+	./util/requisitos.sh
+	./util/nanny.sh
+
+test: test-core test-local test-internet
+
+test-core: $(clitest)
+	./testador/run funcoeszz.md
+
+test-local: $(clitest)
+	./testador/run local
+
+test-internet: $(clitest)
+	./testador/run internet
+
+# Download clitest, the tester program that runs our test-suite.
+$(clitest):
+	curl --location --silent --output $(clitest) $(clitest_url)
+	chmod +x $(clitest)
+
+clean:
+	rm -f $(clitest)

--- a/testador/run
+++ b/testador/run
@@ -24,9 +24,8 @@ no_internet=$(echo "$all" | grep -F -v -x -f <(echo "$internet"))
 
 # Check requirements
 $tester -V > /dev/null || {
-	printf '%s\n' "Ops... Não achei o programa testador: clitest"
-	printf '%s\n' 'Baixe-o deste endereço:'
-	printf '%s\n' 'https://raw.github.com/aureliojargas/clitest/master/clitest'
+	printf '%s\n' 'Ops... Não achei o programa testador.'
+	printf '%s\n' 'Para resolver, execute: make testador/clitest'
 	exit 1
 }
 


### PR DESCRIPTION
Para centralizar comandos comuns para os desenvolvedores executarem
localmente.

O arquivo de configuração do Travis CI também foi adaptado para usar
os comandos novos.

Note que no Makefile também foi automatizada a instalação do clitest.
