### PR TITLE
Resolvendo glitch Mac OS Catalina e case/esac dentro de subshell.

### DIFF
--- a/zz/zzconfere.sh
+++ b/zz/zzconfere.sh
@@ -88,10 +88,10 @@ zzconfere ()
 	codregex=$(
 		zzloteria $tipo $num |
 		case "$tipo" in
-			quina | megasena | timemania | sorte)
+			(quina | megasena | timemania | sorte)
 				sed '3!d;s/^[[:blank:]]*/\\</;s/[[:blank:]]\{1,\}/\\>\|\\</g;s/$/\\> /'
 			;;
-			duplasena)
+			(duplasena)
 				sed 's/^[[:blank:]]*/\\</;s/[[:blank:]]\{1,\}/\\>\|\\</g;s/$/\\> /' |
 				if test -z "$num"
 				then
@@ -100,7 +100,7 @@ zzconfere ()
 					sed -n '5p;8p;'
 				fi
 			;;
-			lotomania)
+			(lotomania)
 				sed 's/^[[:blank:]]*/\\</;s/[[:blank:]]\{1,\}/\\>\|\\</g;s/$/\\>/' |
 				if test -z "$num"
 				then
@@ -110,7 +110,7 @@ zzconfere ()
 				fi |
 				tr '\n' '|'
 			;;
-			lotof[aá]cil)
+			(lotof[aá]cil)
 				sed 's/^[[:blank:]]*/\\</;s/[[:blank:]]\{1,\}/\\>\|\\</g;s/$/\\>/' |
 				sed -n '3,5p' |
 				tr '\n' '|'


### PR DESCRIPTION
Oi Aurelio!

Este glitch que resolvi aqui ocorria no Mac OS toda vez que se dava um `source "$ZZPATH"` na versão atual do funcoeszz.

Veja:

```
~/Downloads/Pessoal/etudes/etudes_bash/funcoeszz/zz $ source "$ZZPATH"
-bash: /Users/teixeira/Downloads/Pessoal/etudes/etudes_bash/funcoeszz/zz/zzconfere.sh: line 93: syntax error near unexpected token `;;'
-bash: /Users/teixeira/Downloads/Pessoal/etudes/etudes_bash/funcoeszz/zz/zzconfere.sh: line 93: `	;;'
~/Downloads/Pessoal/etudes/etudes_bash/funcoeszz/zz $ git stash pop
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   zzconfere.sh

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (e58cc6e0a36e8d64455665d452c3fa3f159d6041)
~/Downloads/Pessoal/etudes/etudes_bash/funcoeszz/zz $ source "$ZZPATH"
~/Downloads/Pessoal/etudes/etudes_bash/funcoeszz/zz $ #sem erro
```

Até onde identifiquei, o problema está no `case/esac` dentro de um subshell: precisa do `(` inicial para as condições.

Verifique e me diga o que achou! Valeu.