### PR TITLE
Nanny: CI, usa exit code, só mostra checks que falharam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 
 script:
   - ./util/requisitos.sh
+  - ./util/nanny.sh
   - ./testador/run funcoeszz.md
   - ./testador/run internet_travis
 

--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -7,44 +7,70 @@
 
 cd "$(dirname "$0")/.." || exit 1  # go to repo root
 
+exit_code=0
+tab=$(printf '\t')
+
 eco() { echo -e "\033[36;1m$*\033[m"; }
+
+check() {  # $1=name, $2=wrong
+	if test -n "$2"
+	then
+		eco ----------------------------------------------------------------
+		eco "* $1"
+		echo "$2"
+		exit_code=1
+	fi
+}
 
 ### Testes relacionados ao arquivo e sua estrutura básica
 
-eco ----------------------------------------------------------------
-eco "* Funções que não são UTF-8"
-file --mime zz/*.sh off/*.sh | grep -vi 'utf-8'
+check "Funções que não são UTF-8" \
+$(
+	file --mime zz/*.sh off/*.sh |
+	grep -vi 'utf-8'
+)
 
-eco ----------------------------------------------------------------
-eco "* Funções com nome de arquivo inválido"
-ls -1 zz/*.sh off/*.sh | grep -v '/zz[a-z0-9]*\.sh$'
+check "Funções com nome de arquivo inválido" \
+$(
+	ls -1 zz/*.sh off/*.sh |
+	grep -v '/zz[a-z0-9]*\.sh$'
+)
 
-eco ----------------------------------------------------------------
-eco "* Funções com erro ao importar (source)"
-for f in zz/*.sh off/*.sh; do (source "$f"); done
+check "Funções com erro ao importar (source)" \
+$(for f in zz/*.sh off/*.sh
+do
+	(source "$f" 2>&1)
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções cujo início não é 'zznome ()\\\n'"
-for f in zz/*.sh off/*.sh; do grep "^zz[a-z0-9]* ()$" "$f" >/dev/null || echo "$f"; done
+check "Funções cujo início não é 'zznome ()\\\n'" \
+$(for f in zz/*.sh off/*.sh
+do
+	grep "^zz[a-z0-9]* ()$" "$f" >/dev/null || echo "$f"
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções que não terminam em '}' na última linha"
-for f in zz/*.sh off/*.sh; do tail -1 "$f" | grep "^}$" >/dev/null || echo "$f"; done
+check "Funções que não terminam em '}' na última linha" \
+$(for f in zz/*.sh off/*.sh
+do
+	tail -1 "$f" | grep "^}$" >/dev/null || echo "$f"
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções que falta a quebra de linha na última linha"
-for f in zz/*.sh off/*.sh; do tail -1 "$f" | od -a | grep '}.*nl' >/dev/null || echo "$f"; done
+check "Funções que falta a quebra de linha na última linha" \
+$(for f in zz/*.sh off/*.sh
+do
+	tail -1 "$f" | od -a | grep '}.*nl' >/dev/null || echo "$f"
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções cujo nome não bate com o nome do arquivo"
-for f in zz/*.sh off/*.sh; do grep "^$(basename "$f" .sh) " "$f" >/dev/null || echo "$f"; done
+check "Funções cujo nome não bate com o nome do arquivo" \
+$(for f in zz/*.sh off/*.sh
+do
+	grep "^$(basename "$f" .sh) " "$f" >/dev/null || echo "$f"
+done)
 
 
 ### Testes relacionados ao cabeçalho
 
-eco ----------------------------------------------------------------
-eco "* Funções com o cabeçalho mal formatado"
-for f in zz/*.sh off/*.sh
+check "Funções com o cabeçalho mal formatado" \
+$(for f in zz/*.sh off/*.sh
 do
 	wrong=$(sed -n '
 
@@ -115,26 +141,28 @@ do
 			/^# -\{76\}$/! { s/^/Esperava -----------, veio /p; q; }
 		}' "$f")
 		test -n "$wrong" && printf "%s: %s\n" "$f" "$wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções cuja linha separadora é estranha"
-for f in zz/*.sh off/*.sh; do test "$(grep -Ec '^# -{76}$' "$f")" = 2 || echo "$f"; done
+check "Funções cuja linha separadora é estranha" \
+$(for f in zz/*.sh off/*.sh
+do
+	test "$(grep -Ec '^# -{76}$' "$f")" = 2 || echo "$f"
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com a descrição sem ponto final"
-for f in zz/*.sh off/*.sh; do
+check "Funções com a descrição sem ponto final" \
+$(for f in zz/*.sh off/*.sh
+do
 	wrong=$(sed -n '2 {
 		/^# http/ n
 		# Deve acabar em ponto final
 		/\.$/! p
 		}' "$f")
 	test -n "$wrong" && echo "$f: $wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com a descrição com mais de um ponto ."
-for f in zz/*.sh off/*.sh; do
+check "Funções com a descrição com mais de um ponto ." \
+$(for f in zz/*.sh off/*.sh
+do
 	test "$f" = off/zzranking.sh && continue  # tem 2 pontos mas é OK
 	wrong=$(sed -n '2 {
 		/^# http/ n
@@ -142,79 +170,79 @@ for f in zz/*.sh off/*.sh; do
 		/\. .*\./ p
 		}' "$f")
 	test -n "$wrong" && echo "$f: $wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com conteúdo inválido no campo Autor:"
-for f in zz/*.sh off/*.sh
+check "Funções com conteúdo inválido no campo Autor:" \
+$(for f in zz/*.sh off/*.sh
 do
-	wrong=$(grep '^# Autor:' "$f" | grep -Ev '^# Autor: [^ ].*$')
+	wrong=$(
+		grep '^# Autor:' "$f" |
+		grep -Ev '^# Autor: [^ ].*$'
+	)
 	test -n "$wrong" && echo "$f: $wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com a data inválida no campo Desde:"
-for f in zz/*.sh off/*.sh
+check "Funções com a data inválida no campo Desde:" \
+$(for f in zz/*.sh off/*.sh
 do
-	wrong=$(grep '^# Desde:' "$f" | grep -Ev '^# Desde: [0-9]{4}-[0-9]{2}-[0-9]{2}$')
+	wrong=$(
+		grep '^# Desde:' "$f" |
+		grep -Ev '^# Desde: [0-9]{4}-[0-9]{2}-[0-9]{2}$'
+	)
 	test -n "$wrong" && echo "$f: $wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com número inválido no campo Versão: (deve ser decimal)"
-for f in zz/*.sh  #off/*.sh
+check "Funções com número inválido no campo Versão: (deve ser decimal)" \
+$(for f in zz/*.sh  #off/*.sh
 do
-	wrong=$(grep '^# Versão:' "$f" | grep -Ev '^# Versão: [0-9][0-9]?$')
+	wrong=$(
+		grep '^# Versão:' "$f" |
+		grep -Ev '^# Versão: [0-9][0-9]?$'
+	)
 	test -n "$wrong" && echo "$f: $wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com o campo inválido Licença:"
-for f in zz/*.sh
+check "Funções com o campo inválido Licença:" \
+$(for f in zz/*.sh
 do
 	wrong=$(grep '^# Licença:' "$f")
 	test -n "$wrong" && echo "$f: $wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com campo Requisitos: vazio"
-for f in zz/*.sh off/*.sh
+check "Funções com campo Requisitos: vazio" \
+$(for f in zz/*.sh off/*.sh
 do
 	grep '^# Requisitos: *$' "$f" > /dev/null && echo "$f"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com vírgulas no campo Requisitos: (use só espaços)"
-for f in zz/*.sh off/*.sh
+check "Funções com vírgulas no campo Requisitos: (use só espaços)" \
+$(for f in zz/*.sh off/*.sh
 do
 	grep '^# Requisitos:.*,' "$f" > /dev/null && echo "$f"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com cabeçalho >78 colunas"
-for f in zz/*.sh off/*.sh
+check "Funções com cabeçalho >78 colunas" \
+$(for f in zz/*.sh off/*.sh
 do
 	grep '^# ' "$f" | grep -E '^.{79}' |
-		grep -v DESATIVADA: |
-		grep -v '^# Requisitos:' |
-		# Insere o path do arquivo no início da linha
-		sed "s|^|$f: |" |
-		# Exceções pontuais
-		grep -v '^zz/zzloteria\.sh: # Resultados da quina' |
-		grep -v '^zz/zzpalpite\.sh: # quina, megasena,' |
-		grep -v '^zz/zzpalpite\.sh: # Uso: zzpalpite'
-done
+	grep -v DESATIVADA: |
+	grep -v '^# Requisitos:' |
+	# Insere o path do arquivo no início da linha
+	sed "s|^|$f: |" |
+	# Exceções pontuais
+	grep -v '^zz/zzloteria\.sh: # Resultados da quina' |
+	grep -v '^zz/zzpalpite\.sh: # quina, megasena,' |
+	grep -v '^zz/zzpalpite\.sh: # Uso: zzpalpite'
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com cabeçalho usando TAB (use só espaços)"
-grep -H '^#.*	' zz/*.sh off/*.sh
+check "Funções com cabeçalho usando TAB (use só espaços)" \
+$(grep -H "^#.*$tab" zz/*.sh off/*.sh)
 
 ### Desativada por enquanto, ainda não sei o que fazer com isso
 #
-# eco ----------------------------------------------------------------
-# eco "* Funções com campo desconhecido"
 # campos='Obs\.|Opções|Uso|Ex\.|Autor|Desde|Versão|Requisitos|Nota'
-# for f in zz/*.sh off/*.sh
+# check "Funções com campo desconhecido" \
+# $(for f in zz/*.sh off/*.sh
 # do
 # 	wrong=$(
 # 		grep -E '^# [A-Z][a-z.]+: ' "$f" |
@@ -223,59 +251,63 @@ grep -H '^#.*	' zz/*.sh off/*.sh
 # 		grep -Ev "$campos" |
 # 		sed 1q)  # só mostra o primeiro pra não poluir
 # 	test -n "$wrong" && echo "$f: $wrong"
-# done
+# done)
 #
 
 
 ### Testes relacionados ao ambiente ZZ
 
-eco ----------------------------------------------------------------
-eco "* Funções que não usam 'zzzz -h'"
-for f in zz/*.sh  # off/*.sh
+check "Funções que não usam 'zzzz -h'" \
+$(for f in zz/*.sh  # off/*.sh
 do
 	grep 'zzzz -h ' "$f" >/dev/null || echo "$f"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções cuja chamada 'zzzz -h' está incorreta"
-for f in zz/*.sh  # off/*.sh
+check "Funções cuja chamada 'zzzz -h' está incorreta" \
+$(for f in zz/*.sh  # off/*.sh
 do
 	test "$f" = zz/zzzz.sh && continue  # zzzz lida com seu próprio -h
 	# zzzz -h cores $1 && return
 	grep -F "zzzz -h $(basename "$f" .sh | sed 's/^zz//') \"\$1\" && return" "$f" >/dev/null || echo "$f"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções com o nome errado em 'zztool uso'"
-for f in zz/*.sh  # off/*.sh
+check "Funções com o nome errado em 'zztool uso'" \
+$(for f in zz/*.sh  # off/*.sh
 do
-	wrong=$(grep -E 'zztool( -e)? uso ' "$f" | grep -Ev "zztool( -e)? uso $(basename "$f" .sh | sed 's/^zz//')")
+	wrong=$(
+		grep -E 'zztool( -e)? uso ' "$f" |
+		grep -Ev "zztool( -e)? uso $(basename "$f" .sh | sed 's/^zz//')"
+	)
 	test -n "$wrong" && echo "$f"  # && echo "$wrong"
-done
+done)
 
-eco ----------------------------------------------------------------
-eco "* Funções desativadas sem data e motivo para o desligamento"
-for f in off/*.sh
+check "Funções desativadas sem data e motivo para o desligamento" \
+$(for f in off/*.sh
 do
 	# # DESATIVADA: 2002-10-30 O programa acabou.
 	grep -E '^# DESATIVADA: [0-9]{4}-[0-9]{2}-[0-9]{2} .{10,}' "$f" >/dev/null || echo "$f"
-done
+done)
 
 
 ### Testes de segurança
 
-eco ----------------------------------------------------------------
-eco "* Funções que não colocaram aspas ao redor de \$ZZTMP"
-grep '$ZZTMP' zz/*.sh off/*.sh | grep -v '"'
+check "Funções que não colocaram aspas ao redor de \$ZZTMP" \
+$(
+	grep -F '$ZZTMP' zz/*.sh off/*.sh |
+	grep -v '"'
+)
 
 # https://github.com/funcoeszz/funcoeszz/wiki/Arquivos-Temporarios
-eco ----------------------------------------------------------------
-eco "* Funções que usaram nome inválido em \$ZZTMP.nome"
-grep '$ZZTMP' zz/*.sh | grep -Ev '^zz/zz([^.]*)\.sh:.*\$ZZTMP\.\1' |
+check "Funções que usaram nome inválido em \$ZZTMP.nome" \
+$(
+	grep -F '$ZZTMP' zz/*.sh |
+	grep -Ev '^zz/zz([^.]*)\.sh:.*\$ZZTMP\.\1' |
 	# Exceções conhecidas
 	grep -Ev '^zz/zz(tool|zz)\.sh:'
+)
 
 
+exit $exit_code
 
 # Outros:
 #


### PR DESCRIPTION
Refactor e melhoria no funcionamento da Nanny, pra ela poder ser usada
no CI.

- Agora ela sai com exit code 1 quando algum check falha.

- A execução da Nanny foi adicionada ao Travis CI.

- Antes todos os checks eram sempre mostrados no output, independente
  se falhou ou não. Agora só aparece na saída os checks que falharam.
  Se nenhum check falhar, não terá nenhuma saída.

Nenhum check foi adicionado ou removido.