### PR TITLE
zzcoin: cache local, removido --all, aceita múltiplas moedas

### DIFF
--- a/testador/zzcoin.sh
+++ b/testador/zzcoin.sh
@@ -4,7 +4,10 @@ $ zzcoin | grep Bitcoin
 BCH : Bitcoin Cash
 BTC : Bitcoin
 $ zzcoin BTC | sed 's/[0-9.]\{1,\}/9/g'
-R$ 9,9
+BTC: R$ 9,9
 $ zzcoin ltc | sed 's/[0-9.]\{1,\}/9/g'
-R$ 9,9
+LTC: R$ 9,9
+$ zzcoin btc ltc | sed 's/[0-9.]\{1,\}/9/g'
+BTC: R$ 9,9
+LTC: R$ 9,9
 $

--- a/testador/zzcoin.sh
+++ b/testador/zzcoin.sh
@@ -1,4 +1,10 @@
-$ zzcoin                                   #=> --lines 23
-$ zzcoin btc | sed 's/[0-9.]\{1,\}/9/g'    #=> R$ 9,9
-$ zzcoin ltc | sed 's/[0-9.]\{1,\}/9/g'    #=> R$ 9,9
-$ zzcoin bch | sed 's/[0-9.]\{1,\}/9/g'    #=> R$ 9,9
+$ zzcoin foo
+Moeda desconhecida: foo
+$ zzcoin | grep Bitcoin
+BCH : Bitcoin Cash
+BTC : Bitcoin
+$ zzcoin BTC | sed 's/[0-9.]\{1,\}/9/g'
+R$ 9,9
+$ zzcoin ltc | sed 's/[0-9.]\{1,\}/9/g'
+R$ 9,9
+$

--- a/zz/zzcoin.sh
+++ b/zz/zzcoin.sh
@@ -1,15 +1,15 @@
 # ----------------------------------------------------------------------------
 # Retorna a cotação de criptomoedas em Reais (Bitcoin, Litecoins, etc.).
 #
-# Uso: zzcoin [criptomoeda]
-# Ex.: zzcoin       # Lista todas as criptomoedas disponíveis
-#      zzcoin btc   # Cotação do Bitcoin
-#      zzcoin ltc   # Cotação do Litecoin
-#      zzcoin eth   # Cotação do Ethereum
+# Uso: zzcoin [criptomoeda ...]
+# Ex.: zzcoin              # Lista todas as criptomoedas disponíveis
+#      zzcoin btc          # Cotação do Bitcoin
+#      zzcoin ltc          # Cotação do Litecoin
+#      zzcoin btc ltc eth  # Cotação do Bitcoin, Litecoin e Ethereum
 #
 # Autor: Tárcio Zemel <tarciozemel (a) gmail com>
 # Desde: 2014-03-24
-# Versão: 8
+# Versão: 9
 # Requisitos: zzzz zztool zzmaiusculas zznumero zzsemacento
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
@@ -18,7 +18,7 @@ zzcoin ()
 	zzzz -h coin "$1" && return
 
 	# Variáveis gerais
-	local moeda_informada
+	local moeda
 	local url="https://www.mercadobitcoin.com.br"
 
 	# https://www.mercadobitcoin.com.br/api-doc/
@@ -80,28 +80,31 @@ zzcoin ()
 		ZRX : 0x
 	"
 
-	if test -n "$1"
+	if test $# -eq 0
 	then
-		case "$1" in
-		*)
-			moeda_informada=$(echo "${1}" | zzmaiusculas | zzsemacento)
+		# Lista as moedas disponíveis
+		echo "$moedas" | tr -d '\t' | grep .
+		return 0
+	fi
 
-			if zztool grep_var "$moeda_informada :" "$moedas"
-			then
-				# Uma criptomoeda específica
-				zztool dump "${url}/api/${moeda_informada}/ticker/" |
+	while test $# -gt 0
+	do
+		moeda=$(echo "$1" | zzmaiusculas | zzsemacento)
+
+		if zztool grep_var "$moeda :" "$moedas"
+		then
+			# Mostra a cotação de uma criptomoeda específica
+			printf '%s: ' $moeda
+			zztool dump "${url}/api/${moeda}/ticker/" |
 				sed 's/.*"last": *"//;s/", *"buy.*//' |
 				zznumero -m
 
-			else
-				# Se não informou moeda válida, termina
-				zztool erro "Moeda desconhecida: $1"
-				return 1
-			fi
-		;;
-		esac
-	else
-		# Listando as moedas disponíveis
-		echo "$moedas" | tr -d '\t' | grep .
-	fi
+		else
+			# Se não informou moeda válida, termina
+			zztool erro "Moeda desconhecida: $1"
+			return 1
+		fi
+
+		shift
+	done
 }

--- a/zz/zzcoin.sh
+++ b/zz/zzcoin.sh
@@ -1,18 +1,16 @@
 # ----------------------------------------------------------------------------
 # Retorna a cotação de criptomoedas em Reais (Bitcoin, Litecoins, etc.).
-# Com o argumento -a ou --all mostra a cotação de todas as criptomoedas.
 #
-# Uso: zzcoin [criptomoeda| -a | --all]
+# Uso: zzcoin [criptomoeda]
 # Ex.: zzcoin       # Lista todas as criptomoedas disponíveis
-#      zzcoin -a    # Cotação de todas as criptomoedas da lista
 #      zzcoin btc   # Cotação do Bitcoin
 #      zzcoin ltc   # Cotação do Litecoin
 #      zzcoin eth   # Cotação do Ethereum
 #
 # Autor: Tárcio Zemel <tarciozemel (a) gmail com>
 # Desde: 2014-03-24
-# Versão: 7
-# Requisitos: zzzz zztool zzmaiusculas zznumero zzpad zzsemacento zzxml
+# Versão: 8
+# Requisitos: zzzz zztool zzmaiusculas zznumero zzsemacento
 # Tags: internet, consulta
 # ----------------------------------------------------------------------------
 zzcoin ()
@@ -20,38 +18,75 @@ zzcoin ()
 	zzzz -h coin "$1" && return
 
 	# Variáveis gerais
-	local moeda_informada moeda
+	local moeda_informada
 	local url="https://www.mercadobitcoin.com.br"
-	local moedas=$(zztool source "${url}/api-doc/" |
-		zzxml --tidy |
-		sed -n '
-			/<div class="tab domain">/,/div>/{
-				/div>/q
-				/<[^>]*>/d
-				p
-			}
-		' |
-		awk '
-			!/ : /  { coin = $1; next }
-			!/None/ { print coin $0 }
-		')
+
+	# https://www.mercadobitcoin.com.br/api-doc/
+	local moedas="\
+		AAVE : Aave
+		ACMFT : Fan Token ASR
+		ACORDO01 : None
+		ASRFT : Fan Token ASR
+		ATMFT : Fan Token ATM
+		AXS : Axie Infinity Shard
+		BAL : Balancer
+		BARFT : BARFT
+		BAT : Basic Attention token
+		BCH : Bitcoin Cash
+		BTC : Bitcoin
+		CAIFT : Fan Token CAI
+		CHZ : Chiliz
+		COMP : Compound
+		CRV : Curve
+		DAI : Dai
+		DAL : Balancer
+		ENJ : Enjin
+		ETH : Ethereum
+		GALFT : Fan Token GAL
+		GRT : The Graph
+		IMOB01 : None
+		IMOB02 : None
+		JUVFT : Fan Token JUV
+		KNC : Kyber Network
+		LINK : CHAINLINK
+		LTC : Litecoin
+		MANA : Decentraland
+		MBCONS01 : Cota de Consórcio 01
+		MBCONS02 : Cota de Consórcio 02
+		MBFP01 : None
+		MBFP02 : None
+		MBFP03 : None
+		MBFP04 : None
+		MBFP05 : None
+		MBPRK01 : Precatório MB SP01
+		MBPRK02 : Precatório MB SP02
+		MBPRK03 : Precatório MB BR03
+		MBPRK04 : Precatório MB RJ04
+		MBVASCO01 : MBVASCO01
+		MCO2 : MCO2
+		MKR : Maker
+		OGFT : Fan Token ASR
+		PAXG : PAX Gold
+		PSGFT : Fan Token PSG
+		REI : Ren
+		REN : Ren
+		SNX : Synthetix
+		UMA : Uma
+		UNI : Uniswap
+		USDC : USD Coin
+		WBX : WiBX
+		XRP : XRP
+		YFI : Yearn
+		ZRX : 0x
+	"
 
 	if test -n "$1"
 	then
 		case "$1" in
-		-a | --all)
-			# Todas as criptomoedas
-			for moeda_informada in $(echo "${moedas}" | sed 's/ *:.*//' | zztool lines2list)
-			do
-				moeda=$(echo "$moedas" | awk -F ' : ' ' /'${moeda_informada}'/ {print $2 "(" $1 ")"}')
-				echo "$(zzpad 31 ${moeda}): $(zzcoin ${moeda_informada})"
-			done
-			return
-		;;
 		*)
 			moeda_informada=$(echo "${1}" | zzmaiusculas | zzsemacento)
 
-			if zztool grep_var "|${moeda_informada}|" $(echo "|${moedas}" | sed 's/ *:.*//' | tr '\n' '|')
+			if zztool grep_var "$moeda_informada :" "$moedas"
 			then
 				# Uma criptomoeda específica
 				zztool dump "${url}/api/${moeda_informada}/ticker/" |
@@ -60,13 +95,13 @@ zzcoin ()
 
 			else
 				# Se não informou moeda válida, termina
-				zztool -e uso coin
-				return
+				zztool erro "Moeda desconhecida: $1"
+				return 1
 			fi
 		;;
 		esac
 	else
 		# Listando as moedas disponíveis
-		echo "$moedas"
+		echo "$moedas" | tr -d '\t' | grep .
 	fi
 }


### PR DESCRIPTION
Eu consigo acessar a URL da documentação da API normalmente pelo
navegador, porém, via linha de comando está dando erro:

    $ curl https://www.mercadobitcoin.com.br/api-doc/
    error code: 1020
    $

Essa página era usada para extrair a lista das moedas disponíveis.
Em vez disso, agora a lista está hardcoded na função. Não é o ideal,
mas funciona.

Outras alterações:

- Mensagem de erro clara quando se informa uma moeda desconhecida.

- Testes atualizados.

- A saída foi modificada para sempre mostrar o nome da moeda antes
  da cotação.

- Removida a opção `--all`. São 55 moedas ao todo, e o código anterior
  neste caso fazia 55 requisições ao site. Me parece demais. Em seu lugar,
  agora a função aceita receber múltiplas moedas como argumento.