### PR TITLE
zzhoramin: detecta horário inválido

### DIFF
--- a/testador/zzhoramin.sh
+++ b/testador/zzhoramin.sh
@@ -10,3 +10,6 @@ $ zzhoramin -0:01	#=> -1
 $ zzhoramin -1:00	#=> -60
 $ zzhoramin -1:01	#=> -61
 $ zzhoramin -01:01	#=> -61
+$ zzhoramin foo
+Hora inválida 'foo'
+$

--- a/zz/zzhoramin.sh
+++ b/zz/zzhoramin.sh
@@ -8,7 +8,7 @@
 #
 # Autor: Marcell S. Martini <marcellmartini (a) gmail com>
 # Desde: 2008-12-05
-# Versão: 4
+# Versão: 5
 # Requisitos: zzzz zzhora zztestar
 # Tags: tempo, conversão
 # ----------------------------------------------------------------------------
@@ -21,10 +21,15 @@ zzhoramin ()
 
 	operacao='+'
 
-	# Testa se o parâmetro passado é uma hora valida
-	if ! zztestar hora "${1#-}"; then
+	if test $# -eq 0
+	then
+		# Nenhuma hora informada, usa a hora atual
 		hora=$(zzhora agora | cut -d ' ' -f 1)
 	else
+		# Valida a hora informada
+		# (note que o possível sinal de menos é removido)
+		zztestar -e hora "${1#-}" || return 1
+
 		hora="$1"
 	fi
 


### PR DESCRIPTION
O código anterior estava usando a hora atual quando se passava uma
hora inválida. Mas esse não é o comportamento esperado, nem o
documentado, que menciona apenas que isso acontece quando não se
informa um horário.

Agora, ao se passar uma hora inválida, o usuário é avisado sobre:

    $ zzhoramin foo
    Hora inválida 'foo'
    $

O comportamento de usar a hora atual quando nenhum horário é informado
permanece inalterado.