### PR TITLE
util/alinhamento.sh: CI, usa exit code, só mostra checks que falharam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ clitest_url = https://raw.githubusercontent.com/aureliojargas/clitest/master/cli
 .PHONY: clean lint test test-core test-local test-internet
 
 lint:
+	./util/alinhamento.sh
 	./util/requisitos.sh
 	./util/nanny.sh
 

--- a/util/alinhamento.sh
+++ b/util/alinhamento.sh
@@ -7,22 +7,44 @@
 
 
 cd "$(dirname "$0")/.." || exit 1  # go to repo root
-cd zz || exit 1
 
-../funcoeszz tool eco "Linha que inicia com um espaço"
-grep '^ ' ./* |
-	grep -v -E '^zz(google|palpite)'  # caso válido, sed multilinha
+exit_code=0
 
-../funcoeszz tool eco "Linha com Tab e espaço misturados"
-grep '	 ' ./* |
+eco() {
+    echo -e "\033[36;1m$*\033[m"
+}
+
+check() {  # $1=name, $2=wrong
+	if test -n "$2"
+	then
+		eco ----------------------------------------------------------------
+		eco "* $1"
+		echo "$2"
+		exit_code=1
+	fi
+}
+
+check "Linha que inicia com um espaço" "$(
+	grep -r '^ ' zz/ |
+	grep -v '^zz/zzpalpite.sh: /g'  # caso válido, sed multilinha
+)"
+
+check "Linha com Tab e espaço misturados" "$(
+	grep -r '	 ' zz/ |
 	# [\t ]: Dentro de colchetes, é regex
 	grep -Fv '[	 ]' |
 	# Em sed para substituição
 	grep -Fv "sed 's"
+)"
 
-../funcoeszz tool eco "Linha com Tabs ou espaços inúteis no final"
-grep '[^ 	][ 	]\{1,\}$' ./* |
-	grep -v '^zzxml.sh:.*Foo $'  # exceção, usado num comentário
+check "Linha com Tabs ou espaços inúteis no final" "$(
+	grep -r -E '[^ 	][ 	]+$' zz/ |
+	grep -v '^zz/zzxml.sh:.*Foo $'  # exceção, usado num comentário
+)"
 
-../funcoeszz tool eco "Linhas vazias, mas com brancos"
-grep -E '^[	 ]+$' ./*
+check "Linhas vazias, mas com brancos" "$(
+	grep -r -E '^[	 ]+$' zz/
+)"
+
+
+exit $exit_code

--- a/zz/zztool.sh
+++ b/zz/zztool.sh
@@ -173,7 +173,7 @@ zztool ()
 		list2lines)
 			# Limpa lista dos argumentos *ou* a STDIN e retorna um item por linha
 			# Lista: um dois três | um, dois, três | um;dois;três
-			zztool multi_stdin "$@" | 
+			zztool multi_stdin "$@" |
 				sed 's/[;,]/ /g' |
 				tr -s '\t' ' ' |
 				tr ' ' '\n' |


### PR DESCRIPTION
Exatamente a mesma coisa que foi feita no commit 1b248459, para a
nanny.sh, foi feita agora para o alinhamento.sh.

Também contém já os fixes para o $2, igual foi feito no commit
fec73478.

Também apaga um espaço em branco inútil, que foi o único problema
detectado pelo alinhamento.sh na master.