### PR TITLE
Usa GitHub Actions para os linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/en/actions/reference
+
+name: Lint
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
   - make testador/clitest
 
 script:
-  - make lint
   - make test-core
   - ./testador/run internet_travis
 


### PR DESCRIPTION
A ideia é migrar do Travis CI (que ultimamente anda fazendo movimentos
estranhos, em seu modelo de negócios) para o GitHub Actions.

Aqui está um começo light, apenas dos linters.