### PR TITLE
testador: Baixa clitest se necessário

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ addons:
       - bc
       - links
 
-before_install:
-  - make testador/clitest
-
 script:
   - ./testador/run internet_travis
 

--- a/testador/run
+++ b/testador/run
@@ -16,18 +16,19 @@ tester='bash clitest'
 
 cd "$script_dir"
 
+# Download clitest if necessary
+$tester -V > /dev/null || {
+	make -C .. testador/clitest || {
+		printf '%s\n' 'Erro ao instalar o programa testador (clitest)'
+		exit 1
+	}
+}
+
 # For Travis exceptions, see https://github.com/funcoeszz/funcoeszz/issues/355
 internet=$("$zz_root"/util/metadata.sh tags | awk '/^zz.* internet/{sub(/zz\//,"");printf $1 "\n"}')
 internet_travis=$(echo "$internet" | grep -E -v '^zz(distro|linux|chavepgp)\.sh$')
 all=$(ls -1 zz*.sh)
 no_internet=$(echo "$all" | grep -F -v -x -f <(echo "$internet"))
-
-# Check requirements
-$tester -V > /dev/null || {
-	printf '%s\n' 'Ops... Não achei o programa testador.'
-	printf '%s\n' 'Para resolver, execute: make testador/clitest'
-	exit 1
-}
 
 # Create temporary file with ZZ init in full paths
 cat > "$tmp" <<EOF


### PR DESCRIPTION
Não tem sentido só mostrar uma mensagem de erro, sendo que o clitest é
requisito obrigatório para rodar os testes.

A partir de agora, toda vez que o `testador/run` for chamado, ele
baixa o clitest caso seja necessário.