### PR TITLE
Usa GitHub Actions para testar as funções de internet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,24 @@
 name: Test
 on: push
 jobs:
+
   core:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: make test-core
+
+  internet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Required by `zztool dump`, used by many internet-crawler functions
+      - run: sudo apt-get install links
+
+      # Using Python to avoid the gotcha with the trapped SIGPIPE:
+      # https://github.com/aureliojargas/github-actions-sandbox/pull/4
+      - run: |
+          cmd = "./testador/run internet"
+          import subprocess; subprocess.run(cmd, shell=True, check=True)
+        shell: python


### PR DESCRIPTION
O Travis CI também está configurado para testar as funções que usam
a internet. Por enquanto, o GitHub Actions irá rodar em paralelo, pra
podermos comparar ambos.

A ideia é usar somente um no futuro, o que for melhor.