### PR TITLE
CI: Usa Ubuntu 22.04 pra arrumar o SIGPIPE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,19 @@ on:
 jobs:
 
   core:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - run: make test-core
 
   internet:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
       # Required by `zztool dump`, used by many internet-crawler functions
       - run: sudo apt-get install links
 
-      # Using Python to avoid the gotcha with the trapped SIGPIPE:
+      # Using env to avoid the gotcha with the trapped SIGPIPE:
       # https://github.com/aureliojargas/github-actions-sandbox/pull/4
-      - run: |
-          cmd = "./testador/run internet"
-          import subprocess; subprocess.run(cmd, shell=True, check=True)
-        shell: python
+      - run: env --default-signal=PIPE ./testador/run internet


### PR DESCRIPTION
Atualizando o Ubuntu para a versão mais recente é possível usar a opção nova `--default-signal` do comando `env`. Com essa opção pode-se desfazer o `trap` do sinal SIGPIPE, que o GitHub Actions faz por padrão e afeta o funcionamento da suíte de testes.

Veja mais detalhes em:
https://github.com/aureliojargas/github-actions-sandbox/pull/4