### PR TITLE
Imagem Docker para dev das ZZ (devcontainer, GitHub Codespaces)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# Dockerfile do ambiente de desenvolvimento das Funções ZZ.
+# Feito para ser usado no VS Code ou via web com o GitHub Codespaces.
+
+# A imagem base é um Ubuntu 22.04 com git e ferramentas de
+# desenvolvimento para shell e Python. Veja detalhes em
+# https://github.com/aureliojargas/devcontainer
+FROM ghcr.io/aureliojargas/devcontainer
+
+# Instala softwares adicionais que são requisitos para algumas funções
+RUN apt update && export DEBIAN_FRONTEND=noninteractive \
+    && apt --yes install --no-install-recommends \
+    bc \
+    file \
+    gawk \
+    links \
+    && rm -rf /var/lib/apt/lists/*
+
+# O 'mawk' é removido para que o 'gawk' tenha precedência quando chamar
+# o comando 'awk'. https://github.com/funcoeszz/funcoeszz/issues/753
+RUN apt --yes remove mawk
+
+# Configura as Funções ZZ
+# O repositório das ZZ será colocado em /workspaces/funcoeszz/
+ENV PATH=/workspaces/funcoeszz:$PATH \
+    ZZPATH=/workspaces/funcoeszz/funcoeszz \
+    ZZDIR=/workspaces/funcoeszz/zz \
+    ZZTMPDIR=/tmp \
+    LC_ALL=C.UTF-8

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+// https://aka.ms/devcontainer.json
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "remoteUser": "vscode"
+}


### PR DESCRIPTION
Estamos em 2022, e hoje há soluções muito bacanas para que se possa programar em um projeto, sem precisar bagunçar o seu ambiente local ([VS Code + devcontainer](https://code.visualstudio.com/docs/remote/containers)) ou até mesmo nem usar o ambiente local e fazer tudo pelo navegador ([GitHub Codespaces](https://github.com/features/codespaces)).

Para poder usar estas soluções, é preciso de uma imagem Docker que traga já instaladas todas as ferramentas que o programador precisa, além de uma configuração no arquivo `devcontainer.json`.

É isto o que este commit traz.

A imagem base (vide https://github.com/aureliojargas/devcontainer) é um Ubuntu 22.04 com git mais ferramentas de desenvolvimento para shell e Python.

Para as Funções ZZ, foi necessário instalar software adicional (`bc`, `gawk`, ...) e setar as variáveis de ambiente para que o comando `funcoeszz` já esteja funcional após a inicialização do contêiner.