### PR TITLE
Ativa shellcheck no Makefile e no CI

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -8,3 +8,7 @@ disable=SC2001
 # SC2016: Expressions don't expand in single quotes, use double quotes for that.
 # Sabemos como usar as aspas simples :)
 disable=SC2016
+
+# SC2012: Use find instead of ls to better handle non-alphanumeric filenames.
+# Geralmente usamos `ls zz/*.sh | ...`, então não há problema.
+disable=SC2012

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,12 +1,10 @@
 # https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files
 
-# Disabled checks
-# ---------------
-#
 # SC2001: See if you can use ${variable//search/replace} instead.
-#      -> We prefer sed, and we avoid bash2+ variable expansions for portability
-#
+# Preferimos usar o sed, alem de evitar expansões de variaveis do bash2+ por
+# questões de portabilidade.
+disable=SC2001
+
 # SC2016: Expressions don't expand in single quotes, use double quotes for that.
-#      -> We know when to use single quotes :)
-#
-disable=SC2001,SC2016
+# Sabemos como usar as aspas simples :)
+disable=SC2016

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint: shellcheck
 	./util/nanny.sh
 
 shellcheck:
-	shellcheck info/*.sh manpage/*.sh release/*.sh
+	shellcheck info/*.sh manpage/*.sh release/*.sh util/*.sh
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint: shellcheck
 	./util/nanny.sh
 
 shellcheck:
-	shellcheck info/*.sh manpage/*.sh release/*.sh util/*.sh
+	shellcheck funcoeszz info/*.sh manpage/*.sh release/*.sh util/*.sh
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ lint: shellcheck
 	./util/nanny.sh
 
 shellcheck:
-	shellcheck funcoeszz info/*.sh manpage/*.sh release/*.sh util/*.sh
+	shellcheck funcoeszz testador/run \
+		info/*.sh \
+		manpage/*.sh \
+		release/*.sh \
+		util/*.sh
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint: shellcheck
 	./util/nanny.sh
 
 shellcheck:
-	shellcheck manpage/*.sh release/*.sh
+	shellcheck info/*.sh manpage/*.sh release/*.sh
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@ clitest_url = https://raw.githubusercontent.com/aureliojargas/clitest/master/cli
 
 .PHONY: clean lint test test-core test-local test-internet
 
-lint:
+lint: shellcheck
 	./util/alinhamento.sh
 	./util/requisitos.sh
 	./util/nanny.sh
+
+shellcheck:
+	shellcheck manpage/*.sh release/*.sh
 
 test: test-core test-local test-internet
 
@@ -25,4 +28,4 @@ $(clitest):
 	chmod +x $(clitest)
 
 clean:
-	rm -f $(clitest)
+	rm -f $(clitest) release/funcoeszz-dev.sh

--- a/funcoeszz
+++ b/funcoeszz
@@ -61,7 +61,7 @@ ZZTMPDIR_DFT="${TMPDIR:-/tmp}"    # diretório temporário
 # 1. Resolução do parâmetro $0:
 # https://github.com/aureliojargas/livro-shell/issues/2#issuecomment-830872380
 
-# 1.1. "bash arquivo.sh" vs. "source arquivo.sh" 
+# 1.1. "bash arquivo.sh" vs. "source arquivo.sh"
 # (https://superuser.com/a/176788/42896)
 
 # Quando o arquivo de script é executado com "bash arquivo.sh",
@@ -168,7 +168,7 @@ _extrai_ajuda() {
 }
 
 # Limpa conteúdo do arquivo de ajuda
-> "$ZZAJUDA"
+: > "$ZZAJUDA"
 
 # Salva o texto de ajuda das funções inclusas neste arquivo
 # (presentes na versão tudo-em-um)
@@ -190,8 +190,8 @@ test -r "$ZZPATH" && _extrai_ajuda "$ZZPATH" >> "$ZZAJUDA"
 ### Passo 1
 
 # Limpa arquivos temporários que guardam as listagens
-> "$ZZTMP.on"
-> "$ZZTMP.off"
+: > "$ZZTMP.on"
+: > "$ZZTMP.off"
 
 # Lista de funções a desligar: uma por linha, com prefixo zz
 zz_off=$(
@@ -287,6 +287,7 @@ do
 	test -r "$zz_arquivo" || continue
 
 	# Inclui a função na shell atual
+	# shellcheck disable=SC1090
 	. "$zz_arquivo"
 
 	# Extrai o texto de ajuda
@@ -307,6 +308,7 @@ echo '-------' | sed 's/.*/&&&&&&&&&&&/' >> "$ZZAJUDA"
 if test -z "$ZZDIR" -a -n "$zz_off"
 then
 	# Desliga todas em uma só linha (note que não usei aspas)
+	# shellcheck disable=SC2086
 	unset $zz_off
 
 	# Agora apaga os textos da ajuda, montando um script em sed e aplicando

--- a/testador/run
+++ b/testador/run
@@ -11,11 +11,12 @@
 # See util/lista.sh for a list of available function groups.
 
 tests_dir=$(dirname "$0")
+# shellcheck disable=SC2164,SC2103
 zz_root=$(cd "$tests_dir"; cd ..; pwd)  # handles absolute and relative
 tmp='./run.tmp'
 tester='bash clitest'
 
-cd "$tests_dir"
+cd "$tests_dir" || exit
 
 # Download clitest if necessary
 $tester -V > /dev/null || {
@@ -61,13 +62,14 @@ case "$1" in
 		else
 			# User argument is unknown. Maybe it contains test
 			# filenames. Let's try them directly.
-			tests="$@"
+			tests="$*"  # our filenames have no spaces
 		fi
 	;;
 esac
 
 # Run the tests
 # Note: To remove the dots ........ change 'dot' to 'none'
+# shellcheck disable=SC2086
 $tester --progress dot --pre-flight ". $tmp" $tests
 exitcode=$?
 

--- a/util/lista.sh
+++ b/util/lista.sh
@@ -14,9 +14,9 @@
 cd "$(dirname "$0")/.." || exit 1  # go to repo root
 
 function zzname_from_path() {
-    while read path
+    while read -r path
     do
-        basename $path .sh
+        basename "$path" .sh
     done
 }
 
@@ -61,7 +61,7 @@ case "$1" in
         internet=$(./util/lista.sh internet | wc -l)
         no_internet=$(./util/lista.sh no-internet | wc -l)
 
-        echo $internet + $no_internet = $all
+        echo "$internet + $no_internet = $all"
         test "$((internet + no_internet))" -eq "$all" || {
             echo FAIL >&2
             exit 1

--- a/util/nanny.sh
+++ b/util/nanny.sh
@@ -32,6 +32,7 @@ check "Funções que não são UTF-8" "$(
 )"
 
 check "Funções com nome de arquivo inválido" "$(
+	# shellcheck disable=SC2010
 	ls -1 zz/*.sh off/*.sh |
 	grep -v '/zz[a-z0-9]*\.sh$'
 )"
@@ -39,6 +40,7 @@ check "Funções com nome de arquivo inválido" "$(
 check "Funções com erro ao importar (source)" "$(
 	for f in zz/*.sh off/*.sh
 	do
+		# shellcheck disable=SC1090
 		(source "$f" 2>&1)
 	done
 )"


### PR DESCRIPTION
Agora é oficial, passaremos a exigir que os scripts não contenham problemas apontados pelo [shellcheck](https://www.shellcheck.net/), para poderem ser mergeados.

Por enquanto ainda não podemos ativar a verificação em todo o repositório, pois ainda há muito a arrumar. A partir desta PR, estamos verificando os seguintes locais:

- `funcoeszz` (core)
- `info/*.sh`
- `manpage/*.sh`
- `release/*.sh`
- `testador/run`
- `util/*.sh`

Veja os commits desta PR para mais informações.

Fica faltando a pasta `zz` com seus quase 200 arquivos shell lá dentro...

Issue: #691