### PR TITLE
shellcheck: Arruma SC2196 SC2197 SC2162 SC2035 SC2164 SC1007

### DIFF
--- a/.github/workflows/test-zz.yaml
+++ b/.github/workflows/test-zz.yaml
@@ -26,6 +26,7 @@ jobs:
     needs: build-matrix
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false  # always run all jobs, regardless of failures
       matrix:
         zz: ${{ fromJson(needs.build-matrix.outputs.zzs) }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ lint: shellcheck
 # verificações mais simples de arrumar. São elas:
 # - egrep/fgrep -> grep -E/-F
 # - read -r
+# - * -> ./* pra evitar conflito de glob com -arquivos --estranhos
 shellcheck:
 	shellcheck funcoeszz testador/run \
 		info/*.sh \
@@ -20,7 +21,8 @@ shellcheck:
 		util/*.sh
 	shellcheck zz/*.sh --shell=bash \
 		--include SC2196,SC2197 \
-		--include SC2162
+		--include SC2162 \
+		--include SC2035
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ lint: shellcheck
 # - egrep/fgrep -> grep -E/-F
 # - read -r
 # - * -> ./* pra evitar conflito de glob com -arquivos --estranhos
+# - cd || exit
 shellcheck:
 	shellcheck funcoeszz testador/run \
 		info/*.sh \
@@ -22,7 +23,8 @@ shellcheck:
 	shellcheck zz/*.sh --shell=bash \
 		--include SC2196,SC2197 \
 		--include SC2162 \
-		--include SC2035
+		--include SC2035 \
+		--include SC2164
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,17 @@ lint: shellcheck
 	./util/requisitos.sh
 	./util/nanny.sh
 
+# Na segunda chamada, estamos indo aos poucos nas zz/*.sh, ligando somente as
+# verificações mais simples de arrumar. São elas:
+# - egrep/fgrep -> grep -E/-F
 shellcheck:
 	shellcheck funcoeszz testador/run \
 		info/*.sh \
 		manpage/*.sh \
 		release/*.sh \
 		util/*.sh
+	shellcheck zz/*.sh --shell=bash \
+		--include SC2196,SC2197
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ lint: shellcheck
 # - read -r
 # - * -> ./* pra evitar conflito de glob com -arquivos --estranhos
 # - cd || exit
+# - foo= -> foo=''
 shellcheck:
 	shellcheck funcoeszz testador/run \
 		info/*.sh \
@@ -24,7 +25,8 @@ shellcheck:
 		--include SC2196,SC2197 \
 		--include SC2162 \
 		--include SC2035 \
-		--include SC2164
+		--include SC2164 \
+		--include SC1007
 
 test: test-core test-local test-internet
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ lint: shellcheck
 # Na segunda chamada, estamos indo aos poucos nas zz/*.sh, ligando somente as
 # verificações mais simples de arrumar. São elas:
 # - egrep/fgrep -> grep -E/-F
+# - read -r
 shellcheck:
 	shellcheck funcoeszz testador/run \
 		info/*.sh \
@@ -18,7 +19,8 @@ shellcheck:
 		release/*.sh \
 		util/*.sh
 	shellcheck zz/*.sh --shell=bash \
-		--include SC2196,SC2197
+		--include SC2196,SC2197 \
+		--include SC2162
 
 test: test-core test-local test-internet
 

--- a/testador/zzmaiores.sh
+++ b/testador/zzmaiores.sh
@@ -1,23 +1,49 @@
-$ zzmaiores | sed '/clitest/d' | head -n 9 | cut -f 2
-zznumero.sh
-zzdatafmt.sh
-zztestar.sh
-zzansi2html.out.html
-zztimer.sh
-zzf1.sh
-zzdata.sh
-zzconjugar.sh
-zzascii.sh
-$ zzmaiores -n 3 | cut -f 2
-clitest
-zznumero.sh
-zzdatafmt.sh
-$ zzmaiores -n 3 zza* | cut -f 2
-zzansi2html.out.html
-zzascii.sh
-zzarrumacidade.sh
-$ zzmaiores -n 3 -- zza* | cut -f 2
-zzansi2html.out.html
-zzascii.sh
-zzarrumacidade.sh
+$ zzmaiores | tr 0-9 9
+99	clitest
+99	zznumero.sh
+99	zzdatafmt.sh
+99	zztestar.sh
+99	zzansi9html.out.html
+99	zztimer.sh
+99	zzf9.sh
+99	zzdata.sh
+99	zzconjugar.sh
+99	zzascii.sh
+$ zzmaiores -n 3 | tr 0-9 9
+99	clitest
+99	zznumero.sh
+99	zzdatafmt.sh
+$ zzmaiores -n 3 zza* | tr 0-9 9
+99	zzansi9html.out.html
+99	zzascii.sh
+9	zzarrumacidade.sh
+$ zzmaiores -n 3 -- zza* | tr 0-9 9
+99	zzansi9html.out.html
+99	zzascii.sh
+9	zzarrumacidade.sh
+$ zzmaiores -x
+Opção inválida -x
+$
+
+# Quando usa -f, a lista de arquivos vem com um ./ na frente e usa bytes
+# em vez de kb...
+
+$ zzmaiores -n 3 | tr 0-9 9
+99	clitest
+99	zznumero.sh
+99	zzdatafmt.sh
+$ zzmaiores -n 3 -f | tr 0-9 9
+99999	./clitest
+99999	./zzdatafmt.sh
+99999	./zznumero.sh
+$
+
+# Teste da opção recursiva. Note que o path usado como argumento é
+# replicado na saída, como prefixo para todos os itens. A pasta em si (o
+# total) aparece como primeiro item.
+
+$ zzmaiores -n 3 -r ../testador | tr 0-9 9
+9999	../testador
+99	../testador/clitest
+99	../testador/zznumero.sh
 $

--- a/testador/zzmaiores.sh
+++ b/testador/zzmaiores.sh
@@ -8,4 +8,16 @@ zzf1.sh
 zzdata.sh
 zzconjugar.sh
 zzascii.sh
+$ zzmaiores -n 3 | cut -f 2
+clitest
+zznumero.sh
+zzdatafmt.sh
+$ zzmaiores -n 3 zza* | cut -f 2
+zzansi2html.out.html
+zzascii.sh
+zzarrumacidade.sh
+$ zzmaiores -n 3 -- zza* | cut -f 2
+zzansi2html.out.html
+zzascii.sh
+zzarrumacidade.sh
 $

--- a/testador/zzshuffle.sh
+++ b/testador/zzshuffle.sh
@@ -1,13 +1,23 @@
 # Preparação
-$ seq 5 > _tmp1
+
+$ seq 20 > _tmp1
 $ zzshuffle _tmp1 > _tmp2
 $ zzshuffle _tmp1 > _tmp3
 $
 
+# Confere que os arquivos misturados são diferentes do original
+
 $ diff -q _tmp1 _tmp2 > /dev/null; echo $?	#=> 1
 $ diff -q _tmp1 _tmp3 > /dev/null; echo $?	#=> 1
+$
+
+# Confere que os arquivos misturados são diferentes entre si, ou seja,
+# cada misturada deve produzir um resultado diferente
+
 $ diff -q _tmp2 _tmp3 > /dev/null; echo $?	#=> 1
+$
 
 # Limpeza
+
 $ rm -f _tmp[123]
 $

--- a/zz/zzbrasileirao.sh
+++ b/zz/zzbrasileirao.sh
@@ -95,7 +95,7 @@ zzbrasileirao ()
 	fi |
 	sed 's/^|//;s/| *$//;s/a$/ /' |
 	awk 'NR==1 && /Final/ {next};1' |
-	while IFS='|' read pos time resto
+	while IFS='|' read -r pos time resto
 	do
 		unset cor
 		zztool grep_var 'Grupo' "$pos" && echo '--------------------------------'

--- a/zz/zzcep.sh
+++ b/zz/zzcep.sh
@@ -62,7 +62,7 @@ zzcep ()
 		sed '2,$ { /LOGRADOURO/d; }' |
 		zztrim |
 		tr -s ' ' |
-		while IFS="|" read logradouro bairro cidade cep
+		while IFS="|" read -r logradouro bairro cidade cep
 		do
 			echo "$cep $(zzpad 65 $logradouro) $(zzpad 25 $bairro) $(zzpad 30 $cidade) $cep"
 		done |

--- a/zz/zzcodchar.sh
+++ b/zz/zzcodchar.sh
@@ -316,7 +316,7 @@ s/♦/\&	diams	#x2666	#9830	;/g;
 				dec)      sed 's/	.*	/	\&/;s/$/;/;$s/" "/ /';;
 				*)
 					sed 's/	/	\&/g;s/	/;	/2g;s/$/;/' |
-					while read char html hex dec
+					while read -r char html hex dec
 					do
 						echo "$(zzpad 4 $char) $(zzpad 11 $html) $(zzpad 11 $hex) $dec"
 					done |

--- a/zz/zzconfere.sh
+++ b/zz/zzconfere.sh
@@ -125,7 +125,7 @@ zzconfere ()
 		echo "$palpite"
 	else
 		# Quando os números apostados estão listado em um arquivo
-		while read palpite
+		while read -r palpite
 		do
 			echo "$palpite" |
 			sed 's/^[^0-9]*//;s/[^0-9]$//;s/[^0-9]\{1,\}/ /g'

--- a/zz/zzconstantes.sh
+++ b/zz/zzconstantes.sh
@@ -53,7 +53,7 @@ zzconstantes ()
 		zzunescape --html |
 		zzcut -f 1-3 -s -d '_' |
 		sed 's/\([0-9]\) \([0-9]\)/\1\2/g;' |
-		while IFS='_' read a b c
+		while IFS='_' read -r a b c
 		do
 			if test 'i' == "$a"
 			then
@@ -84,7 +84,7 @@ zzconstantes ()
 		sed 's/_[_[:space:] ]\{1,\}/_/g;s/^_*//;s/_*$//;/Adaptado do/d;/retirados/d' |
 		zzsqueeze |
 		sed 's/\([0-9]\) \([0-9]\)/\1\2/g;s/&#1013;/ϵ/' |
-		while IFS='_' read a b c d e
+		while IFS='_' read -r a b c d e
 		do
 			if test -z "$b"
 			then

--- a/zz/zzcotacao.sh
+++ b/zz/zzcotacao.sh
@@ -32,7 +32,7 @@ zzcotacao ()
 			if (NF == 5) print $1 " " $2, $3, $4, $5
 		}
 	}' |
-	while IFS='|' read moeda compra venda var
+	while IFS='|' read -r moeda compra venda var
 	do
 		if test 'Moeda' = "$moeda"
 		then

--- a/zz/zzddd.sh
+++ b/zz/zzddd.sh
@@ -66,7 +66,7 @@ zzddd ()
 		tr -s ' ' |
 		awk '/Saiba como ligar/{print "";next};{printf $0 "|"}' |
 		sed '2,${/DDD/d;}' |
-		while IFS="|" read ddd cidade estado
+		while IFS="|" read -r ddd cidade estado
 		do
 			echo "$(zzpad 3 $ddd) $(zzpad 40 $cidade) $estado"
 		done |

--- a/zz/zzddd.sh
+++ b/zz/zzddd.sh
@@ -47,7 +47,7 @@ zzddd ()
 	# A primeira página ou endereço das várias páginas
 	pagina1=$(zztool source "${url}/busca?word=${dddend}")
 
-	if echo "$pagina1" | fgrep 'nav_pagination">' >/dev/null
+	if echo "$pagina1" | grep -F 'nav_pagination">' >/dev/null
 	then
 		ultima=$(echo "$pagina1" | sed -n '/nav_pagination">/,/ul>/{/\/busca\//{$d;s/.*page=//;s/".*//;p;}}' | sort -n | tail -n 1)
 		url2=$(echo "$pagina1" | sed -n '/nav_pagination">/,/ul>/{/\/busca\//{s/.*href="//;s/page=.*/page=/;p;q;}}')

--- a/zz/zzestado.sh
+++ b/zz/zzestado.sh
@@ -76,7 +76,7 @@ TO:Tocantins:tocantins:Palmas"
 		--formato)
 			fmt="$2"
 			echo "$dados" |
-				while IFS=':' read sigla nome slug capital
+				while IFS=':' read -r sigla nome slug capital
 				do
 					resultado=$(printf %s "$fmt" | sed "
 						s/{sigla}/$sigla/g
@@ -156,7 +156,7 @@ TO:Tocantins:tocantins:Palmas"
 		;;
 		*)
 			echo "$dados" |
-				while IFS=':' read sigla nome slug capital
+				while IFS=':' read -r sigla nome slug capital
 				do
 					echo "$sigla    $(zzpad 22 $nome) $capital"
 				done

--- a/zz/zzf1.sh
+++ b/zz/zzf1.sh
@@ -67,13 +67,13 @@ zzf1 ()
 			case $fopt in
 			driver)
 				sed 's/|/ /2' |
-				while IFS='|' read pontos piloto nac1 construtor nac2
+				while IFS='|' read -r pontos piloto nac1 construtor nac2
 				do
 					echo "$(zzpad -e 5 $pontos)  $(zzpad 25 $piloto) $(zzpad 15 $construtor)  $nac1"
 				done
 			;;
 			constructor)
-				while IFS='|' read pontos construtor nac2
+				while IFS='|' read -r pontos construtor nac2
 				do
 					echo "$(zzpad -e 5 $pontos)  $(zzpad 15 $construtor)  $nac2"
 				done

--- a/zz/zzfatorar.sh
+++ b/zz/zzfatorar.sh
@@ -62,7 +62,7 @@ zzfatorar ()
 			zzdivisores $1 |
 			tr ' ' '\n' |
 			sed '1d; $!{ /.\{1,\}[024568]$/d; }' |
-			while read linha
+			while read -r linha
 			do
 				zzdivisores $linha | awk 'NF==2 {print $2}'
 			done > "$cache"

--- a/zz/zzferiado.sh
+++ b/zz/zzferiado.sh
@@ -72,7 +72,7 @@ zzferiado ()
 		sed 's#^\(..\)/\(..\)#\2/\1#g' |
 		sort -n |
 		sed 's#^\(..\)/\(..\)#\2/\1#g' |
-		while read linha; do
+		while read -r linha; do
 			dia=$(echo $linha | cut -d: -f1)
 			diasemana=$(zzdiadasemana $dia/$ano | zzsemacento)
 			descricao=$(echo $linha | cut -d: -f2)

--- a/zz/zzfutebol.sh
+++ b/zz/zzfutebol.sh
@@ -57,7 +57,7 @@ zzfutebol ()
 			if(i!=6) printf $0 ";" (i==7?"\n":"")
 		}
 	}' |
-	while IFS=';' read data hora time1 placar time2 campeonato
+	while IFS=';' read -r data hora time1 placar time2 campeonato
 	do
 		echo "$(zzdatafmt $data) $hora $(zzpad -e 24 $time1) $(zzpad -a 14 $placar) $(zzpad 24 $time2) $campeonato"
 	done |

--- a/zz/zzhexa2str.sh
+++ b/zz/zzhexa2str.sh
@@ -27,7 +27,7 @@ zzhexa2str ()
 		sed 's/^0x//' |
 
 		# hexa -> str
-		while read hexa
+		while read -r hexa
 		do
 			printf "\\x$hexa"
 		done

--- a/zz/zzhoramin.sh
+++ b/zz/zzhoramin.sh
@@ -46,6 +46,7 @@ zzhoramin ()
 	mm="${mm:-0}"
 
 	# faz o cálculo
+	# shellcheck disable=SC2035
 	mintotal=$(($hh * 60 $operacao $mm))
 
 	# Tcharã!!!!

--- a/zz/zzhowto.sh
+++ b/zz/zzhowto.sh
@@ -37,7 +37,7 @@ zzhowto ()
 		zztool source "$url" |
 			zzxml --untag |
 			zztrim |
-			fgrep '.html' |
+			grep -F '.html' |
 			sed 's/ [0-9][0-9]:.*//' > "$cache"
 	fi
 

--- a/zz/zzhsort.sh
+++ b/zz/zzhsort.sh
@@ -59,7 +59,7 @@ zzhsort ()
 	done
 
 	zztool multi_stdin "$@" |
-	while read linha
+	while read -r linha
 	do
 		if test -z "$linha"
 		then

--- a/zz/zziostat.sh
+++ b/zz/zziostat.sh
@@ -92,7 +92,7 @@ zziostat ()
 	# Executa o iostat, le a saida e agrupa cada "ciclo de execucao"
 	# -d device apenas, -m mostra saida em MB/s
 	iostat -d -m $delay $iteration |
-	while read line
+	while read -r line
 	do
 
 		# Ignorando o cabeçalho do iostat, localizado nas 2 linhas iniciais

--- a/zz/zzmacvendor.sh
+++ b/zz/zzmacvendor.sh
@@ -31,7 +31,7 @@ zzmacvendor ()
 	tr -s ' "' '  ' |
 	zzcut -f 1,3,6 -d "|" | tr '|' '\n' |
 	sed '2{s/,[^,]*$//;}' |
-	while read linha
+	while read -r linha
 	do
 		if test -z "$fab"
 		then

--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -10,7 +10,7 @@
 #
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-08-28
-# Versão: 1
+# Versão: 2
 # Requisitos: zzzz zztrim
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
@@ -39,6 +39,11 @@ zzmaiores ()
 			-r)
 				recursivo=1
 				shift
+			;;
+			--)
+				# Fim das opções, o que vem depois é só nomes de arquivos
+				shift
+				break
 			;;
 			*)
 				break
@@ -81,9 +86,7 @@ zzmaiores ()
 		pastas="$@"
 		if test -z "$pastas" -o "$pastas" = '.'
 		then
-			# Não dá pra usar ./* em vez de * senão ele aparece no resultado
-			# shellcheck disable=SC2035
-			zzmaiores ${recursivo:+-r} -n $limite * .[^.]*
+			zzmaiores ${recursivo:+-r} -n $limite -- * .[^.]*
 			return
 
 		fi

--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -81,6 +81,8 @@ zzmaiores ()
 		pastas="$@"
 		if test -z "$pastas" -o "$pastas" = '.'
 		then
+			# Não dá pra usar ./* em vez de * senão ele aparece no resultado
+			# shellcheck disable=SC2035
 			zzmaiores ${recursivo:+-r} -n $limite * .[^.]*
 			return
 

--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -11,7 +11,7 @@
 # Autor: Aurelio Marinho Jargas, www.aurelio.net
 # Desde: 2001-08-28
 # Versão: 2
-# Requisitos: zzzz zztrim
+# Requisitos: zzzz zztool zztrim
 # Tags: arquivo, consulta
 # ----------------------------------------------------------------------------
 zzmaiores ()
@@ -44,6 +44,10 @@ zzmaiores ()
 				# Fim das opções, o que vem depois é só nomes de arquivos
 				shift
 				break
+			;;
+			-*)
+				zztool erro "Opção inválida $1"
+				return 1
 			;;
 			*)
 				break

--- a/zz/zzmaiores.sh
+++ b/zz/zzmaiores.sh
@@ -101,7 +101,7 @@ zzmaiores ()
 	fi
 	# TODO é K (nem é, só se usar -k -- conferir no SF) se vier do du e bytes se do find
 	echo "$resultado"
-	# | while read tamanho arquivo
+	# | while read -r tamanho arquivo
 	# do
 	# 		echo -e "$(zzbyte $tamanho)\t$arquivo"
 	# done

--- a/zz/zzmcd.sh
+++ b/zz/zzmcd.sh
@@ -48,6 +48,7 @@ zzmcd ()
 	esac
 
 	# Desloca-se ao primeiro diretório criado no último nivel possível
+	# shellcheck disable=SC2164
 	test -d "$1" && test -z "$opt" && cd "$1"
 	return $erro
 }

--- a/zz/zzminiurl.sh
+++ b/zz/zzminiurl.sh
@@ -26,7 +26,7 @@ zzminiurl ()
 	local urlCompara=$(echo "$url" | sed 's/\(.*\:\/\/\)\(bit\.ly\).*/\2/')
 
 	# Se o usuário não informou o protocolo, adiciona o padrão.
-	echo "$url" | egrep '^(https?|ftp|mms)://' >/dev/null || url="$prefixo$url"
+	echo "$url" | grep -E '^(https?|ftp|mms)://' >/dev/null || url="$prefixo$url"
 
 	# Testa se a URL já é encurtada, se sim, expande, senão, encurta.
 	if test 'bit.ly' = "$urlCompara"

--- a/zz/zzora.sh
+++ b/zz/zzora.sh
@@ -24,7 +24,7 @@ zzora ()
 	zztool source "${url}=${cod}" |
 	sed -n "/to_URL.*-${cod}/{s/.*name=//;s/\">.*//;p;}" |
 	zzurldecode |
-	while read link
+	while read -r link
 	do
 		zztool dump "$link" |
 		sed -n "/^ *[A-Z0-9]\{1,\}-$cod/,/-[0-9]\{5\}[^0-9]/p" |

--- a/zz/zzpais.sh
+++ b/zz/zzpais.sh
@@ -106,7 +106,7 @@ zzpais ()
 			}'
 	fi |
 	sed 's/ *| */|/g' |
-	while read linha
+	while read -r linha
 	do
 		if zztool grep_var "|" "$linha"
 		then

--- a/zz/zzplay.sh
+++ b/zz/zzplay.sh
@@ -86,7 +86,7 @@ zzplay ()
 				sed '/^[[:blank:]]*$/d;/^#/d;s/^[[:blank:]]*//g' "$1" |
 				awk 'BEGIN { print "[playlist]" } { print "File" NR "=" $0 }' |
 				sed 's/%\([0-9A-F][0-9A-F]\)/\\\\x\1/g' |
-				while read linha
+				while read -r linha
 				do
 					printf "%b\n" "$linha"
 				done >> $cache
@@ -96,7 +96,7 @@ zzplay ()
 				sed '/^[[:blank:]]*$/d;s/^[[:blank:]]*//g' | sed 's|file://||g' |
 				awk 'BEGIN { print "[playlist]" } { print "File" NR "=" $0 }' |
 				sed 's/%\([0-9A-F][0-9A-F]\)/\\\\x\1/g' |
-				while read linha
+				while read -r linha
 				do
 					printf "%b\n" "$linha"
 				done >> $cache
@@ -105,7 +105,7 @@ zzplay ()
 				zzxml --indent --tag ref "$1" | zzunescape --html | sed '/^[[:blank:]]*$/d' |
 				awk -F'""' 'BEGIN { print "[playlist]" } { print "File" NR "=" $2 }' |
 				sed 's/%\([0-9A-F][0-9A-F]\)/\\\\x\1/g' |
-				while read linha
+				while read -r linha
 				do
 					printf "%b\n" "$linha"
 				done >> $cache

--- a/zz/zzquimica.sh
+++ b/zz/zzquimica.sh
@@ -65,7 +65,7 @@ zzquimica ()
 			s/Ununóctio/Oganesson/; s/Uuo/Og/
 			' |
 		sort -n |
-		while IFS=':' read numero nome simbolo massa orbital familia
+		while IFS=':' read -r numero nome simbolo massa orbital familia
 		do
 			echo "$(zzpad 4 $numero) $(zzpad 13 $nome) $(zzpad 7 $simbolo) $(zzpad 12 $massa) $(zzpad 18 $orbital) $familia"
 		done > "$cache"

--- a/zz/zzromanos.sh
+++ b/zz/zzromanos.sh
@@ -67,7 +67,7 @@ zzromanos ()
 	# Se é um número inteiro positivo, transforma para número romano
 	elif zztool testa_numero "$entrada" && test "$entrada" -lt 4000000
 	then
-		echo "$arabicos_romanos" | { while IFS=: read arabico romano
+		echo "$arabicos_romanos" | { while IFS=: read -r arabico romano
 		do
 			while test "$entrada" -ge "$arabico"
 			do
@@ -84,7 +84,7 @@ zzromanos ()
 	then
 		saida=0
 		# Baseado em http://diveintopython.org/unit_testing/stage_4.html
-		echo "$arabicos_romanos" | { while IFS=: read arabico romano
+		echo "$arabicos_romanos" | { while IFS=: read -r arabico romano
 		do
 			comprimento="${#romano}"
 			while test "$(echo "$entrada" | cut -c$indice-$((indice+comprimento-1)))" = "$romano"

--- a/zz/zzromanos.sh
+++ b/zz/zzromanos.sh
@@ -61,7 +61,7 @@ zzromanos ()
 	if test $# -eq 0
 	then
 		echo "$arabicos_romanos" |
-		egrep '[15]|4000:' | tr -d '\t' | tr : '\t' |
+		grep -E '[15]|4000:' | tr -d '\t' | tr : '\t' |
 		zztac
 
 	# Se é um número inteiro positivo, transforma para número romano
@@ -80,7 +80,7 @@ zzromanos ()
 
 	# Se é uma string que representa um número romano válido,
 	# converte para hindu-arábico
-	elif echo "$entrada" | egrep "$regex_validacao" > /dev/null
+	elif echo "$entrada" | grep -E "$regex_validacao" > /dev/null
 	then
 		saida=0
 		# Baseado em http://diveintopython.org/unit_testing/stage_4.html

--- a/zz/zzselic.sh
+++ b/zz/zzselic.sh
@@ -141,7 +141,7 @@ zzselic ()
 	then
 		saida=$(
 			echo "$saida" |
-				while IFS=';' read v1 v2
+				while IFS=';' read -r v1 v2
 				do
 					echo "$(zzpad 11 $v1) $v2"
 				done

--- a/zz/zzshuffle.sh
+++ b/zz/zzshuffle.sh
@@ -22,7 +22,7 @@ zzshuffle ()
 		# Um número aleatório é colocado no início de cada linha,
 		# depois o sort ordena numericamente, bagunçando a ordem
 		# original. Então os números são removidos.
-		while read linha
+		while read -r linha
 		do
 			echo "$(zzaleatorio) $linha"
 		done |

--- a/zz/zzsubway.sh
+++ b/zz/zzsubway.sh
@@ -28,7 +28,7 @@ zzsubway ()
 	1:molho:mostarda e mel:cebola agridoce:barbecue:parmesão:chipotle:mostarda:maionese
 	*:tempero:sal:vinagre:azeite de oliva:pimenta calabresa:pimenta do reino"
 
-	echo "$cardapio" | while read linha; do
+	echo "$cardapio" | while read -r linha; do
 		quantidade=$(echo "$linha" | cut -d : -f 1 | tr -d '\t')
 		categoria=$( echo "$linha" | cut -d : -f 2)
 		opcoes=$(    echo "$linha" | cut -d : -f 3- | tr : '\n')

--- a/zz/zztestar.sh
+++ b/zz/zztestar.sh
@@ -186,9 +186,9 @@ zztestar ()
 		mac)
 			# Testa se $2 tem um formato de MAC válido
 			# O MAC poderá ser nos formatos 00:00:00:00:00:00, 00-00-00-00-00-00 ou 0000.0000.0000
-			echo "$2" | egrep '^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$' >/dev/null && return 0
-			echo "$2" | egrep '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' >/dev/null && return 0
-			echo "$2" | egrep '^([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}$' >/dev/null && return 0
+			echo "$2" | grep -E '^([0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}$' >/dev/null && return 0
+			echo "$2" | grep -E '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' >/dev/null && return 0
+			echo "$2" | grep -E '^([0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4}$' >/dev/null && return 0
 
 			test -n "$erro" && zztool erro "MAC address inválido '$2'"
 			return 1

--- a/zz/zztv.sh
+++ b/zz/zztv.sh
@@ -48,7 +48,7 @@ zztv ()
 
 		# Lista de canais
 		grep -F '/programacao/' "$cache" |
-		while read linhas
+		while read -r linhas
 		do
 			zztool source "${URL}${linhas}"
 		done |
@@ -119,7 +119,7 @@ zztv ()
 		if test "$desc" = "Agora"
 		then
 			grep -F '/programacao/' "$cache" |
-			while read linhas
+			while read -r linhas
 			do
 				zztool source "${URL}${linhas}"
 			done
@@ -140,7 +140,7 @@ zztv ()
 		if test "$desc" = "Agora"
 		then
 			awk -F '|' '{print $3 "|" $2 "|" $5}' |
-			while IFS='|' read hora canal programa
+			while IFS='|' read -r hora canal programa
 			do
 				echo "$hora  $(zzpad 27 $canal) $programa"
 			done |

--- a/zz/zztv.sh
+++ b/zz/zztv.sh
@@ -47,7 +47,7 @@ zztv ()
 		sed -n '/categoria/{s/" .*//;s/.*"//;p;}' > "$cache"
 
 		# Lista de canais
-		fgrep '/programacao/' "$cache" |
+		grep -F '/programacao/' "$cache" |
 		while read linhas
 		do
 			zztool source "${URL}${linhas}"
@@ -100,7 +100,7 @@ zztv ()
 	fi
 
 	case "$1" in
-	canais) fgrep -v '/programacao/' "$cache" | zzcolunar 4;;
+	canais) grep -Fv '/programacao/' "$cache" | zzcolunar 4;;
 	aberta)                        URL="${URL}/programacao/categoria/Aberta"; flag=1; desc="Aberta";;
 	doc | documentario)            URL="${URL}/programacao/categoria/Documentarios"; flag=1; desc="Documentários";;
 	esporte | esportes | futebol)  URL="${URL}/programacao/categoria/Esportes"; flag=1; desc="Esportes";;
@@ -118,7 +118,7 @@ zztv ()
 		zztool eco $desc
 		if test "$desc" = "Agora"
 		then
-			fgrep '/programacao/' "$cache" |
+			grep -F '/programacao/' "$cache" |
 			while read linhas
 			do
 				zztool source "${URL}${linhas}"

--- a/zz/zzwc.sh
+++ b/zz/zzwc.sh
@@ -102,7 +102,7 @@ zzwc ()
 	then
 		maior=$(
 		echo "$conteudo" |
-		while read linha
+		while read -r linha
 		do
 			printf "%s" "$linha" |
 			if test -n "$mb"


### PR DESCRIPTION
Além de corrigir na pasta `zz/` todos os problemas listados,
eles foram colocados no Makefile para que não voltem a ser
introduzidos no futuro (o CI irá verificar).

Usar egrep/fgrep é considerado coisa do passado 🦕 
POSIX e GNU grep concordam (vide links).

https://github.com/koalaman/shellcheck/wiki/SC2196
SC2196: egrep is non-standard and deprecated

https://github.com/koalaman/shellcheck/wiki/SC2197
SC2197: fgrep is non-standard and deprecated

Outros problemas arrumados nessa PR:

https://github.com/koalaman/shellcheck/wiki/SC2162
read without -r will mangle backslashes

https://github.com/koalaman/shellcheck/wiki/SC2035
Use `./*glob*` or `-- *glob*` so names with dashes won't become options

https://github.com/koalaman/shellcheck/wiki/SC2164
Use cd ... || exit in case cd fails

https://github.com/koalaman/shellcheck/wiki/SC1007
Remove space after = if trying to assign a value

Repeteco do que já tinha sido feito em: 
https://github.com/funcoeszz/funcoeszz/pull/700
https://github.com/funcoeszz/funcoeszz/pull/704

Issue: #691